### PR TITLE
Implementation for SHOW/reboot-cause and SHOW/reboot-cause/history

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -172,6 +172,8 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 		return grpc.Errorf(codes.Unimplemented, "Empty target data not supported")
 	} else if target == "OTHERS" {
 		dc, err = sdc.NewNonDbClient(paths, prefix)
+	} else if target == "SHOW" {
+		return grpc.Errorf(codes.Unimplemented, "SHOW does not support subscribe operations")
 	} else if ((target == "EVENTS") && (mode == gnmipb.SubscriptionList_STREAM)) {
 		dc, err = sdc.NewEventClient(paths, prefix, c.logLevel)
 	} else if _, ok, _, _ := sdc.IsTargetDb(target); ok {

--- a/gnmi_server/reboot_cause_cli_test.go
+++ b/gnmi_server/reboot_cause_cli_test.go
@@ -1,0 +1,260 @@
+package gnmi
+
+// reboot_cause_cli_test.go
+
+// Tests SHOW reboot-cause and SHOW reboot-cause history
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
+)
+
+const (
+	ServerPort   = 8081
+	StateDbNum   = 6
+	TargetAddr   = "127.0.0.1:8081"
+	QueryTimeout = 10
+)
+
+func MockReadFile(fileName string, fileContent string, fileReadErr error) {
+	sdc.ImplIoutilReadFile = func(filePath string) ([]byte, error) {
+		if filePath == fileName {
+			if fileReadErr != nil {
+				return nil, fileReadErr
+			}
+			return []byte(fileContent), nil
+		}
+		return ioutil.ReadFile(filePath)
+	}
+}
+
+func AddDataSet(t *testing.T, dbNum int, fileName string) {
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	rclient := getRedisClientN(t, dbNum, ns)
+	defer rclient.Close()
+	rclient.FlushDB()
+
+	fileContentBytes, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read file: %v, err: %v", fileName, err)
+	}
+
+	fileContent := loadConfig(t, "", fileContentBytes)
+	loadDB(t, rclient, fileContent)
+}
+
+func TestGetShowRebootCause(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	rebootCauseReboot := `{"gen_time": "2025_07_09_17_32_14", "cause": "reboot", "user": "admin", "time": "Wed Jul  9 05:28:24 PM UTC 2025", "comment": "N/A"}`
+	rebootCausePowerLoss := `{"gen_time": "2025_07_10_12_19_14", "cause": "Power Loss", "user": "N/A", "time": "Thur Jul  10 00:14:24 PM UTC 2025", "comment": "N/A"}`
+	rebootCauseHardware := `{"gen_time": "2025_07_08_11_53_50", "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)", "user": "N/A", "time": "N/A", "comment": "Unknown"}`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW reboot-cause error reading",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:       "query SHOW reboot-cause reboot",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseReboot),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCauseReboot, nil)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause Power Loss",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCausePowerLoss),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCausePowerLoss, nil)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause Hardware",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHardware),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCauseHardware, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+	}
+}
+
+func TestGetShowRebootCauseHistory(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	rebootCauseHistoryWatchdogFileName := "../testdata/REBOOT_CAUSE_WATCHDOG.txt"
+	rebootCauseHistoryWatchdog := `{"2025_07_10_20_06_34":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:05:33 PM UTC 2025","user":"admin"},"2025_07_10_20_12_49":{"cause":"fast-reboot","comment":"N/A","time":"Thu Jul 10 08:10:49 PM UTC 2025","user":"admin"},"2025_07_10_20_19_34":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 08:17:34 PM UTC 2025","user":"admin"},"2025_07_10_20_31_14":{"cause":"Watchdog (watchdog, description: Watchdog fired, time: 2025-07-10 20:30:26)","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_10_20_36_35":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:35:34 PM UTC 2025","user":"admin"},"2025_07_10_20_41_54":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:40:52 PM UTC 2025","user":"admin"},"2025_07_10_20_47_15":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:46:13 PM UTC 2025","user":"admin"},"2025_07_11_01_49_30":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:48:29 AM UTC 2025","user":"admin"},"2025_07_11_02_00_24":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:59:22 AM UTC 2025","user":"admin"},"2025_07_11_02_35_51":{"cause":"Unknown","comment":"N/A","time":"N/A","user":"N/A"}}`
+	rebootCauseHistoryHardwareFileName := "../testdata/REBOOT_CAUSE_HARDWARE.txt"
+	rebootCauseHistoryHardware := `{"2025_07_07_02_35_26":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:34:07 AM UTC 2025","user":"admin"},"2025_07_07_02_43_43":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:42:22 AM UTC 2025","user":"admin"},"2025_07_08_05_22_02":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:20:54 AM UTC 2025","user":"admin"},"2025_07_08_05_30_28":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:29:20 AM UTC 2025","user":"admin"},"2025_07_08_07_00_08":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:59:00 AM UTC 2025","user":"admin"},"2025_07_08_09_21_21":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:20:13 AM UTC 2025","user":""},"2025_07_08_09_29_39":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:28:30 AM UTC 2025","user":"admin"},"2025_07_08_10_13_31":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 10:12:23 AM UTC 2025","user":"admin"},"2025_07_08_11_53_50":{"cause":"Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_08_18_29_38":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:28:26 PM UTC 2025","user":"admin"}}`
+	rebootCauseHistoryKernelFileName := "../testdata/REBOOT_CAUSE_KERNEL.txt"
+	rebootCauseHistoryKernel := `{"2025_07_10_14_39_01":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:34:54 PM UTC 2025","user":"admin"},"2025_07_10_14_55_20":{"cause":"Kernel Panic","comment":"N/A","time":"Thu Jul 10 02:51:53 PM UTC 2025","user":"N/A"},"2025_07_10_15_13_45":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:09:38 PM UTC 2025","user":"admin"},"2025_07_10_15_29_52":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:25:44 PM UTC 2025","user":"admin"},"2025_07_10_15_45_47":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:41:43 PM UTC 2025","user":"admin"},"2025_07_10_18_03_28":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:59:18 PM UTC 2025","user":"admin"},"2025_07_10_23_33_47":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:29:44 PM UTC 2025","user":"admin"},"2025_07_10_23_48_41":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:44:41 PM UTC 2025","user":"admin"},"2025_07_11_00_51_52":{"cause":"warm-reboot","comment":"N/A","time":"Fri Jul 11 12:49:13 AM UTC 2025","user":"admin"},"2025_07_11_01_00_54":{"cause":"Kernel Panic","comment":"N/A","time":"Fri Jul 11 12:57:23 AM UTC 2025","user":"N/A"}}`
+	rebootCauseHistoryPowerLossFileName := "../testdata/REBOOT_CAUSE_POWER_LOSS.txt"
+	rebootCauseHistoryPowerLoss := `{"2025_07_09_04_44_38":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 04:41:09 AM UTC 2025","user":"admin"},"2025_07_09_05_11_26":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:07:59 AM UTC 2025","user":"admin"},"2025_07_09_06_52_52":{"cause":"fast-reboot","comment":"N/A","time":"Wed Jul  9 06:50:57 AM UTC 2025","user":"admin"},"2025_07_09_09_23_16":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_09_09_33_28":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_09_17_46_25":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:42:44 PM UTC 2025","user":"admin"},"2025_07_10_02_58_57":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:55:28 AM UTC 2025","user":""},"2025_07_10_05_00_09":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_10_05_27_16":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:23:48 AM UTC 2025","user":"admin"},"2025_07_10_06_31_24":{"cause":"Kernel Panic - Out of memory [Time: Thu Jul 10 06:28:29 AM UTC 2025]","comment":"N/A","time":"N/A","user":"N/A"}}`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW reboot-cause history NO REBOOT-CAUSE dataset",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+		},
+		{
+			desc:       "query SHOW reboot-cause history watchdog",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryWatchdog),
+			valTest:     true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, rebootCauseHistoryWatchdogFileName)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause history hardware",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryHardware),
+			valTest:     true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, rebootCauseHistoryHardwareFileName)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause history kernel",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryKernel),
+			valTest:     true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, rebootCauseHistoryKernelFileName)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause history power loss",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryPowerLoss),
+			valTest:     true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, rebootCauseHistoryPowerLossFileName)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+	}
+}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -13,6 +13,7 @@ import (
 	spb "github.com/sonic-net/sonic-gnmi/proto"
 	spb_gnoi "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt_gnoi "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
+	_ "github.com/sonic-net/sonic-gnmi/show_client"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
 
@@ -401,6 +402,8 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 
 	if target == "OTHERS" {
 		dc, err = sdc.NewNonDbClient(paths, prefix)
+	} else if target == "SHOW" {
+		dc, err = sdc.NewShowClient(paths, prefix)
 	} else if _, ok, _, _ := sdc.IsTargetDb(target); ok {
 		dc, err = sdc.NewDbClient(paths, prefix)
 	} else {

--- a/show_cli/reboot_cause_cli.go
+++ b/show_cli/reboot_cause_cli.go
@@ -1,0 +1,24 @@
+package show_cli
+
+import (
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+const PreviousRebootCauseFilePath = "/host/reboot-cause/previous-reboot-cause.json"
+
+func getPreviousRebootCause() ([]byte, error) {
+	return sdc.GetDataFromFile(PreviousRebootCauseFilePath)
+}
+
+func getRebootCauseHistory() ([]byte, error) {
+	queries := [][]string{
+		{"STATE_DB", "REBOOT_CAUSE"},
+	}
+	tblPaths, err := sdc.CreateTablePathsFromQueries(queries)
+	if err != nil {
+		log.Errorf("Unable to create table paths from queries %v, %v", queries, err)
+		return nil, err
+	}
+	return sdc.GetDataFromTablePaths(tblPaths)
+}

--- a/show_cli/show_paths.go
+++ b/show_cli/show_paths.go
@@ -1,0 +1,17 @@
+package show_cli
+
+import (
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+// All SHOW path and getters are defined here
+func init() {
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "reboot-cause"},
+		getPreviousRebootCause,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "reboot-cause", "history"},
+		getRebootCauseHistory,
+	)
+}

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -1,0 +1,73 @@
+package show_client
+
+import (
+	"fmt"
+	log "github.com/golang/glog"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+const (
+	dbIndex    = 0 // The first index for a query will be the DB
+	tableIndex = 1 // The second index for a query will be the table
+
+	minQueryLength = 2 // We need to support TARGET/TABLE as a minimum query
+	maxQueryLength = 5 // We can support up to 5 elements in query (TARGET/TABLE/(2 KEYS)/FIELD)
+)
+
+func GetDataFromFile(fileName string) ([]byte, error) {
+	fileContent, err := sdc.ImplIoutilReadFile(fileName)
+	if err != nil {
+		log.Errorf("Failed to read'%v', %v", fileName, err)
+		return nil, err
+	}
+	log.V(4).Infof("getDataFromFile, output: %v", string(fileContent))
+	return fileContent, nil
+}
+
+func GetDataFromTablePaths(tblPaths []sdc.TablePath) ([]byte, error) {
+	msi := make(map[string]interface{})
+	for _, tblPath := range tblPaths {
+		err := sdc.TableData2Msi(&tblPath, false, nil, &msi)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return sdc.Msi2Bytes(msi)
+}
+
+func CreateTablePathsFromQueries(queries [][]string) ([]sdc.TablePath, error) {
+	var allPaths []sdc.TablePath
+
+	// Create and validate gnmi path then create table path
+	for _, q := range queries {
+		queryLength := len(q)
+		if queryLength < minQueryLength || queryLength > maxQueryLength {
+			return nil, fmt.Errorf("invalid query %v: must support at least [DB, table] or at most [DB, table, key1, key2, field]", q)
+		}
+
+		// Build a gNMI path for validation:
+		//   prefix = { Target: dbTarget }
+		//   path   = { Elem: [ {Name:table}, {Name:key}, {Name:field} ] }
+
+		dbTarget := q[dbIndex]
+		prefix := &gnmipb.Path{Target: dbTarget}
+
+		table := q[tableIndex]
+		elems := []*gnmipb.PathElem{{Name: table}}
+
+		// Additional elements like keys and fields
+		for i := tableIndex + 1; i < queryLength; i++ {
+			elems = append(elems, &gnmipb.PathElem{Name: q[i]})
+		}
+
+		path := &gnmipb.Path{Elem: elems}
+
+		if tablePaths, err := sdc.PopulateTablePaths(prefix, path); err != nil {
+			return nil, fmt.Errorf("query %v failed: %w", q, err)
+		} else {
+			allPaths = append(allPaths, tablePaths...)
+		}
+	}
+	return allPaths, nil
+}

--- a/sonic_data_client/show_client.go
+++ b/sonic_data_client/show_client.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Workiva/go-datastructures/queue"
+	log "github.com/golang/glog"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	spb "github.com/sonic-net/sonic-gnmi/proto"
+)
+
+type DataGetter func() ([]byte, error)
+type TablePath = tablePath
+
+var showTrie *Trie = NewTrie()
+
+func RegisterCliPath(path []string, getter DataGetter) {
+	n := showTrie.Add(path, getter)
+	if n.meta.(DataGetter) == nil {
+		log.V(1).Infof("Failed to add trie node for %v with %v", path, getter)
+	} else {
+		log.V(2).Infof("Add trie node for %v with %v", path, getter)
+	}
+}
+
+type ShowClient struct {
+	prefix      *gnmipb.Path
+	path2Getter map[*gnmipb.Path]DataGetter
+
+	q       *queue.PriorityQueue
+	channel chan struct{}
+
+	synced sync.WaitGroup  // Control when to send gNMI sync_response
+	w      *sync.WaitGroup // wait for all sub go routines to finish
+	mu     sync.RWMutex    // Mutex for data protection among routines for DbClient
+
+	sendMsg int64
+	recvMsg int64
+	errors  int64
+}
+
+func lookupDataGetter(prefix, path *gnmipb.Path) (DataGetter, error) {
+	stringSlice := []string{prefix.GetTarget()}
+	fullPath := gnmiFullPath(prefix, path)
+
+	elems := fullPath.GetElem()
+	if elems != nil {
+		for i, elem := range elems {
+			log.V(6).Infof("index %d elem : %#v %#v", i, elem.GetName(), elem.GetKey())
+			stringSlice = append(stringSlice, elem.GetName())
+		}
+	}
+	n, ok := showTrie.Find(stringSlice)
+	if ok {
+		getter := n.meta.(DataGetter)
+		return getter, nil
+	}
+	return nil, fmt.Errorf("%v not found in clientTrie tree", stringSlice)
+}
+
+func NewShowClient(paths []*gnmipb.Path, prefix *gnmipb.Path) (Client, error) {
+	var showClient ShowClient
+	showClient.path2Getter = make(map[*gnmipb.Path]DataGetter)
+	showClient.prefix = prefix
+	for _, path := range paths {
+		getter, err := lookupDataGetter(prefix, path)
+		if err != nil {
+			return nil, err
+		}
+		showClient.path2Getter[path] = getter
+	}
+
+	return &showClient, nil
+}
+
+// String returns the target the client is querying.
+func (c *ShowClient) String() string {
+	return fmt.Sprintf("ShowClient Prefix %v  sendMsg %v, recvMsg %v",
+		c.prefix.GetTarget(), c.sendMsg, c.recvMsg)
+}
+
+func (c *ShowClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
+	c.w = w
+
+	var values []*spb.Value
+	ts := time.Now()
+	for gnmiPath, getter := range c.path2Getter {
+		v, err := getter()
+		if err != nil {
+			log.V(3).Infof("GetData error %v for %v", err, v)
+			return nil, err
+		}
+		values = append(values, &spb.Value{
+			Prefix:    c.prefix,
+			Path:      gnmiPath,
+			Timestamp: ts.UnixNano(),
+			Val: &gnmipb.TypedValue{
+				Value: &gnmipb.TypedValue_JsonIetfVal{
+					JsonIetfVal: v,
+				}},
+		})
+	}
+	log.V(6).Infof("Getting #%v", values)
+	log.V(4).Infof("Get done, total time taken: %v ms", int64(time.Since(ts)/time.Millisecond))
+	return values, nil
+}
+
+func PopulateTablePaths(prefix, path *gnmipb.Path) ([]TablePath, error) {
+	m := make(map[*gnmipb.Path][]tablePath)
+	if err := populateDbtablePath(prefix, path, &m); err != nil {
+		return nil, err
+	}
+	return m[path], nil
+}
+
+func Msi2Bytes(msi map[string]interface{}) ([]byte, error) {
+	jv, err := emitJSON(&msi)
+	if err != nil {
+		log.V(2).Infof("emitJSON err %s for %v", err, msi)
+		return nil, fmt.Errorf("emitJSON err %s for %v", err, msi)
+	}
+	if jv == nil {
+		return nil, fmt.Errorf("emitJSON failed to grab json value of map")
+	}
+	return jv, nil
+}
+
+// Unimplemented
+func (c *ShowClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
+}
+
+func (c *ShowClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
+}
+
+func (c *ShowClient) AppDBPollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
+	return
+}
+
+func (c *ShowClient) OnceRun(q *queue.PriorityQueue, once chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
+	return
+}
+
+func (c *ShowClient) Close() error {
+	return nil
+}
+
+func (c *ShowClient) Set(delete []*gnmipb.Path, replace []*gnmipb.Update, update []*gnmipb.Update) error {
+	return nil
+}
+
+func (c *ShowClient) Capabilities() []gnmipb.ModelData {
+	return nil
+}
+
+func (c *ShowClient) SentOne(val *Value) {
+}
+
+func (c *ShowClient) FailedSend() {
+}

--- a/testdata/REBOOT_CAUSE_HARDWARE.txt
+++ b/testdata/REBOOT_CAUSE_HARDWARE.txt
@@ -1,0 +1,62 @@
+{
+    "REBOOT_CAUSE|2025_07_07_02_35_26": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Mon Jul  7 02:34:07 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_07_02_43_43": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Mon Jul  7 02:42:22 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_05_22_02": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 05:20:54 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_05_30_28": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 05:29:20 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_07_00_08": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 06:59:00 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_09_21_21": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 09:20:13 AM UTC 2025",
+        "user": ""
+    },
+    "REBOOT_CAUSE|2025_07_08_09_29_39": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 09:28:30 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_10_13_31": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 10:12:23 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_08_11_53_50": {
+        "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)",
+        "comment": "Unknown",
+        "time": "N/A",
+        "user": "N/A"
+    },
+    "REBOOT_CAUSE|2025_07_08_18_29_38": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Tue Jul  8 06:28:26 PM UTC 2025",
+        "user": "admin"
+    }
+}

--- a/testdata/REBOOT_CAUSE_KERNEL.txt
+++ b/testdata/REBOOT_CAUSE_KERNEL.txt
@@ -1,0 +1,62 @@
+{
+    "REBOOT_CAUSE|2025_07_10_14_39_01": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 02:34:54 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_14_55_20": {
+        "cause": "Kernel Panic",
+        "comment": "N/A",
+        "time": "Thu Jul 10 02:51:53 PM UTC 2025",
+        "user": "N/A"
+    },
+    "REBOOT_CAUSE|2025_07_10_15_13_45": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 03:09:38 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_15_29_52": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 03:25:44 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_15_45_47": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 03:41:43 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_18_03_28": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 05:59:18 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_23_33_47": {
+        "cause": "warm-reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 11:29:44 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_23_48_41": {
+        "cause": "warm-reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 11:44:41 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_11_00_51_52": {
+        "cause": "warm-reboot",
+        "comment": "N/A",
+        "time": "Fri Jul 11 12:49:13 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_11_01_00_54": {
+        "cause": "Kernel Panic",
+        "comment": "N/A",
+        "time": "Fri Jul 11 12:57:23 AM UTC 2025",
+        "user": "N/A"
+    }
+}

--- a/testdata/REBOOT_CAUSE_POWER_LOSS.txt
+++ b/testdata/REBOOT_CAUSE_POWER_LOSS.txt
@@ -1,0 +1,62 @@
+{
+    "REBOOT_CAUSE|2025_07_09_04_44_38": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Wed Jul  9 04:41:09 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_09_05_11_26": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Wed Jul  9 05:07:59 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_09_06_52_52": {
+        "cause": "fast-reboot",
+        "comment": "N/A",
+        "time": "Wed Jul  9 06:50:57 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_09_09_23_16": {
+        "cause": "Power Loss",
+        "comment": "Unknown",
+        "time": "N/A",
+        "user": "N/A"
+    },
+    "REBOOT_CAUSE|2025_07_09_09_33_28": {
+        "cause": "Power Loss",
+        "comment": "Unknown",
+        "time": "N/A",
+        "user": "N/A"
+    },
+    "REBOOT_CAUSE|2025_07_09_17_46_25": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Wed Jul  9 05:42:44 PM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_02_58_57": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 02:55:28 AM UTC 2025",
+        "user": ""
+    },
+    "REBOOT_CAUSE|2025_07_10_05_00_09": {
+        "cause": "Power Loss",
+        "comment": "Unknown",
+        "time": "N/A",
+        "user": "N/A"
+    },
+    "REBOOT_CAUSE|2025_07_10_05_27_16": {
+        "cause": "reboot",
+        "comment": "N/A",
+        "time": "Thu Jul 10 05:23:48 AM UTC 2025",
+        "user": "admin"
+    },
+    "REBOOT_CAUSE|2025_07_10_06_31_24": {
+        "cause": "Kernel Panic - Out of memory [Time: Thu Jul 10 06:28:29 AM UTC 2025]",
+        "comment": "N/A",
+        "time": "N/A",
+        "user": "N/A"
+    }
+}

--- a/testdata/REBOOT_CAUSE_WATCHDOG.txt
+++ b/testdata/REBOOT_CAUSE_WATCHDOG.txt
@@ -1,0 +1,62 @@
+{
+	"REBOOT_CAUSE|2025_07_10_20_06_34": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:05:33 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_12_49": {
+		"cause": "fast-reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:10:49 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_19_34": {
+		"cause": "warm-reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:17:34 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_31_14": {
+		"cause": "Watchdog (watchdog, description: Watchdog fired, time: 2025-07-10 20:30:26)",
+		"comment": "Unknown",
+		"time": "N/A",
+		"user": "N/A"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_36_35": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:35:34 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_41_54": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:40:52 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_10_20_47_15": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Thu Jul 10 08:46:13 PM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_11_01_49_30": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Fri Jul 11 01:48:29 AM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_11_02_00_24": {
+		"cause": "reboot",
+		"comment": "N/A",
+		"time": "Fri Jul 11 01:59:22 AM UTC 2025",
+		"user": "admin"
+	},
+	"REBOOT_CAUSE|2025_07_11_02_35_51": {
+		"cause": "Unknown",
+		"comment": "N/A",
+		"time": "N/A",
+		"user": "N/A"
+	}
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This PR will add the implementation of a new data path "SHOW" that will allow clients to query PATHS similar to show commands that are executed on the host.

In this PR we are focusing on the implementation of `show reboot-cause` and `show reboot-cause history` in telemetry such that the following paths are supported. `SHOW/reboot-cause` and `SHOW/reboot-cause/history`.

#### How I did it

Added a new SHOW client that supports GET operations only and can support both DB reads and non DB reads.

#### How to verify it

UT and manual run (Will add sonic-mgmt testcase)

Test Result:
```
root@sonic:/# gnmi_get -xpath_target SHOW -xpath reboot-cause -target_addr 127.0.0.1:50051 -logtostderr -insecure true        
== getRequest:
prefix: <
  target: "SHOW_CLI"
>
path: <
  elem: <
    name: "reboot-cause"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1752018342645576958
  prefix: <
    target: "SHOW_CLI"
  >
  update: <
    path: <
      elem: <
        name: "reboot-cause"
      >
    >
    val: <
      json_ietf_val: "{\"gen_time\": \"2025_07_08_18_29_38\", \"cause\": \"reboot\", \"user\": \"admin\", \"time\": \"Tue Jul  8 06:28:26 PM UTC 2025\", \"comment\": \"N/A\"}"
    >
  >
>


root@sonic:/# gnmi_get -xpath_target SHOW -xpath reboot-cause/history -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW_CLI"
>
path: <
  elem: <
    name: "reboot-cause"
  >
  elem: <
    name: "history"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1752018358262917568
  prefix: <
    target: "SHOW_CLI"
  >
  update: <
    path: <
      elem: <
        name: "reboot-cause"
      >
      elem: <
        name: "history"
      >
    >
    val: <
      json_ietf_val: "{\"2025_07_07_02_35_26\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Mon Jul  7 02:34:07 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_07_02_43_43\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Mon Jul  7 02:42:22 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_05_22_02\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 05:20:54 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_05_30_28\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 05:29:20 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_07_00_08\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 06:59:00 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_09_21_21\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 09:20:13 AM UTC 2025\",\"user\":\"\"},\"2025_07_08_09_29_39\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 09:28:30 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_10_13_31\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 10:12:23 AM UTC 2025\",\"user\":\"admin\"},\"2025_07_08_11_53_50\":{\"cause\":\"Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)\",\"comment\":\"Unknown\",\"time\":\"N/A\",\"user\":\"N/A\"},\"2025_07_08_18_29_38\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Jul  8 06:28:26 PM UTC 2025\",\"user\":\"admin\"}}"
    >
  >
>
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

