### PR TITLE
Add support for show interface status

### DIFF
--- a/gnmi_server/interface_status_cli_test.go
+++ b/gnmi_server/interface_status_cli_test.go
@@ -1,0 +1,109 @@
+package gnmi_server
+
+import (
+	"testing"
+
+	"crypto/tls"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetShowInterfaceStatus(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	emptyResp := `[]`
+	fullDataWithoutStateDB := `[{"Interface":"Ethernet0","Lanes":"2304,2305,2306,2307","Speed":"100G","MTU":"9100","FEC":"rs","Alias":"etp0","Vlan":"PortChannel1","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"},{"Interface":"Ethernet40","Lanes":"2048,2049,2050,2051","Speed":"100G","MTU":"9100","FEC":"rs","Alias":"etp10","Vlan":"PortChannel1","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"},{"Interface":"Ethernet80","Lanes":"2568,2569,2570,2571","Speed":"100G","MTU":"9100","FEC":"rs","Alias":"etp20","Vlan":"routed","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"},{"Interface":"Ethernet120","Lanes":"2668,2669,2670,2671","Speed":"100G","MTU":"9100","FEC":"rs","Alias":"etp30","Vlan":"trunk","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"},{"Interface":"PortChannel1","Lanes":"N/A","Speed":"200G","MTU":"9100","FEC":"N/A","Alias":"N/A","Vlan":"routed","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"}]`
+	fullDataWithStateDB := `[{"Interface":"Ethernet0","Lanes":"2304,2305,2306,2307","Speed":"200G","MTU":"9100","FEC":"rs","Alias":"etp0","Vlan":"routed","Oper":"up","Admin":"up","Type":"SFP","Asym":"off"},{"Interface":"Ethernet40","Lanes":"2048,2049,2050,2051","Speed":"200G","MTU":"9100","FEC":"rs","Alias":"etp10","Vlan":"routed","Oper":"up","Admin":"up","Type":"SFP","Asym":"off"},{"Interface":"Ethernet80","Lanes":"2568,2569,2570,2571","Speed":"200G","MTU":"9100","FEC":"rs","Alias":"etp20","Vlan":"routed","Oper":"up","Admin":"up","Type":"SFP","Asym":"off"},{"Interface":"Ethernet120","Lanes":"2668,2669,2670,2671","Speed":"200G","MTU":"9100","FEC":"rs","Alias":"etp30","Vlan":"trunk","Oper":"up","Admin":"up","Type":"SFP","Asym":"off"},{"Interface":"PortChannel1","Lanes":"N/A","Speed":"400G","MTU":"9100","FEC":"N/A","Alias":"N/A","Vlan":"routed","Oper":"up","Admin":"up","Type":"N/A","Asym":"off"}]`
+
+	configDbFileName := "../testdata/PORTS.txt"
+	appDbFileName := "../testdata/PORT_TABLE.txt"
+	stateDbFileName := "../testdata/STATE_DB.json"
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW interface status - no data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(emptyResp),
+			valTest:     true,
+		},
+		{
+			desc:       "query SHOW interface status - appl db only",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(fullDataWithoutStateDB),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, ConfigDbNum)
+				FlushDataSet(t, ApplDbNum)
+				AddDataSet(t, ConfigDbNum, configDbFileName)
+				AddDataSet(t, ApplDbNum, appDbFileName)
+			},
+		},
+		{
+			desc:       "query SHOW interface status - appl db + state db",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(fullDataWithoutStateDB),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, ConfigDbNum)
+				FlushDataSet(t, ApplDbNum)
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, ConfigDbNum, configDbFileName)
+				AddDataSet(t, ApplDbNum, appDbFileName)
+				AddDataSet(t, StateDbNum, stateDBFileName)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+	}
+}

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -3,6 +3,7 @@ package show_client
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -424,21 +425,17 @@ func getPortOptics(intf string) string {
 	}
 
 	if _, ok := data["type"]; !ok {
-		if isRj45Port(intf) {
-			return "RJ45"
-		} else {
-			return "N/A"
-		}
+		return "N/A"
 	}
 	return fmt.Sprint(data["type"])
 }
 
-func portSpeedParse(inSpeed, opticsType string) string {
+func portSpeedFmt(inSpeed, opticsType string) string {
 	// fetched speed is in megabits per second
 	speed, err := strconv.Atoi(inSpeed)
 	if err != nil {
-		// If parse fails, return the input as-is (adjust as needed)
-		return inSpeed
+		// If parse fails, return "N/A"
+		return "N/A"
 	}
 
 	if opticsType == "RJ45" && speed <= 1000 {
@@ -449,6 +446,46 @@ func portSpeedParse(inSpeed, opticsType string) string {
 		return fmt.Sprintf("%.1fG", float64(speed)/1000.0)
 	}
 	return fmt.Sprintf("%.0fG", float64(speed)/1000.0)
+}
+
+// portSpeedParse converts a human-readable port speed string to an integer Mbps value.
+// Examples:
+//
+//	"100M"   -> 100
+//	"1G"     -> 1000
+//	"2.5G"   -> 2500
+//	"100000" -> 100000 (assumed already in Mbps)
+//	"N/A" or parse errors -> 0
+func portSpeedParse(speedStr string) int {
+	s := strings.TrimSpace(strings.ToUpper(speedStr))
+	if s == "" || s == "N/A" {
+		return 0
+	}
+
+	if strings.HasSuffix(s, "G") {
+		v := strings.TrimSuffix(s, "G")
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0
+		}
+		return int(math.Round(f * 1000.0))
+	}
+
+	if strings.HasSuffix(s, "M") {
+		v := strings.TrimSuffix(s, "M")
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0
+		}
+		return int(math.Round(f))
+	}
+
+	// Assume raw number already represents Mbps
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return int(math.Round(f))
 }
 
 func getPortOperSpeed(intf string) string {
@@ -479,10 +516,152 @@ func getPortOperSpeed(intf string) string {
 		opticsType, err := getPortOptics(intf)
 		if err != nil {
 			log.Errorf("Failed to get optics type for port %s: %v", intf, err)
-			return "", err
+			return "N/A", err
 		}
-		return portSpeedParse(fmt.Sprint(stateData["speed"]), opticsType)
+		return portSpeedFmt(fmt.Sprint(stateData["speed"]), opticsType)
 	}
+}
+
+func getIntfModeMap(ports []string) map[string]string {
+	queries := [][]string{
+		{"CONFIG_DB", "VLAN_MEMBER"},
+	}
+	vlanMemberTable, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Failed to get VLAN_MEMBER table from CONFIG_DB: %v", err)
+		return nil
+	}
+
+	// Get the map of interfaces to VLANs
+	vlanMembers := map[string]string{}
+	for key := range vlanMemberTable {
+		content := strings.Split(key, "|")
+		vlanMemberKey := content[1]
+
+		vlanMembers[vlanMemberKey] = content[0]
+	}
+
+	queries = [][]string{
+		{"CONFIG_DB", "PORTCHANNEL_MEMBER"},
+	}
+	portChannelMemberTable, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Failed to get PORTCHANNEL_MEMBER table from CONFIG_DB: %v", err)
+		return nil
+	}
+
+	// Get the map of interfaces to Portchannels
+	portChannelMembers := map[string]string{}
+	for key := range portChannelMemberTable {
+		content := strings.Split(key, "|")
+		portChannelMemberKey := content[1]
+
+		portChannelMembers[portChannelMemberKey] = content[0]
+	}
+
+	// Create a map to hold the interface mode
+	intfModeMap := make(map[string]string)
+	for i := range ports {
+		port := ports[i]
+		queries = [][]string{
+			{"CONFIG_DB", "PORT", port},
+		}
+		portData, err := GetMapFromQueries(queries)
+		if err != nil {
+			log.Errorf("Failed to get port data for %s: %v", port, err)
+			continue
+		}
+
+		if mode, ok := portData["mode"]; ok {
+			intfModeMap[port] = fmt.Sprint(mode)
+		} else if _, ok := portChannelMembers[port]; ok {
+			intfModeMap[port] = portChannelMembers[port]
+		} else if _, ok := vlanMembers[port]; ok {
+			intfModeMap[port] = "trunk"
+		} else {
+			intfModeMap[port] = "routed"
+		}
+	}
+	return intfModeMap
+}
+
+func getPortchannelModeMap(portchannels []string) map[string]string {
+	queries := [][]string{
+		{"CONFIG_DB", "VLAN_MEMBER"},
+	}
+	vlanMemberTable, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Failed to get VLAN_MEMBER table from CONFIG_DB: %v", err)
+		return nil
+	}
+
+	// Get the map of interfaces to VLANs
+	vlanMembers := map[string]string{}
+	for key := range vlanMemberTable {
+		content := strings.Split(key, "|")
+		vlanMemberKey := content[1]
+
+		vlanMembers[vlanMemberKey] = content[0]
+	}
+
+	for i := range portchannels {
+		port := portchannels[i]
+		queries = [][]string{
+			{"CONFIG_DB", "PORTCHANNEL", port},
+		}
+		portData, err := GetMapFromQueries(queries)
+		if err != nil {
+			log.Errorf("Failed to get port data for %s: %v", port, err)
+			continue
+		}
+
+		if mode, ok := portData["mode"]; ok {
+			poModeMap[port] = fmt.Sprint(mode)
+		} else if _, ok := vlanMembers[port]; ok {
+			poModeMap[port] = "trunk"
+		} else {
+			poModeMap[port] = "routed"
+		}
+	}
+	return poModeMap
+}
+
+func getPortchannelSpeedMap(portchannels []string) map[string]string {
+	queries := [][]string{
+		{"CONFIG_DB", "PORTCHANNEL_MEMBER"},
+	}
+	portChannelMemberTable, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Failed to get PORTCHANNEL_MEMBER table from CONFIG_DB: %v", err)
+		return nil
+	}
+
+	// Get the map of Portchannels to Interfaces
+	portChannelMembership := map[string][]string{}
+	for key := range portChannelMemberTable {
+		content := strings.Split(key, "|")
+		portChannel := content[0]
+
+		portChannelMembership[portChannel] = append(portChannelMembership[portChannel], content[1])
+	}
+
+	// Calculate the speed for each portchannel by summing the speeds of its member interfaces
+	poSpeedMap := make(map[string]string)
+	for portchannel := range portChannelMembership {
+		speedList := []string{}
+		for i := range portChannelMembership[portchannel] {
+			speed := getPortOperSpeed(portChannelMembership[portchannel][i])
+			speedList = append(speedList, speed)
+		}
+
+		aggSpeed := 0
+		for _, speed := range speedList {
+			aggSpeed += portSpeedParse(speed)
+		}
+		poSpeedMap[portchannel] = portSpeedFmt(fmt.Sprint(aggSpeed))
+	}
+
+	return poSpeedMap
 }
 
 func getSubIntfsFromAppDB(intf string) ([]string, error) {
@@ -551,20 +730,23 @@ func getInterfaceStatus(options sdc.OptionMap) ([]byte, error) {
 	portchannels := getPortchannelIntfsFromConfigDB(intf)
 	ports = natsortInterfaces(ports)
 	portchannels = natsortInterfaces(portchannels)
+	intfModeMap := getIntfModeMap(ports)
+	poModeMap := getPortchannelModeMap(portchannels)
+	poSpeedMap := getPortchannelSpeedMap(portchannels)
 	interfaceStatus := make([]map[string]string, 0, len(ports)+len(portchannels))
 
 	// Get status of front panel interfaces
 	for i := range ports {
 		port := ports[i]
 		portLanesStatus := ""
-		portOperSpeed := ""
+		portOperSpeed := getPortOperSpeed(port)
 		portMtuStatus := ""
 		portFecStatus := ""
 		portAlias := ""
-		vlan := ""
+		portMode := intfModeMap[port]
 		operStatus := ""
 		adminStatus := ""
-		portOpticsType := ""
+		portOpticsType := getPortOptics(port)
 		portPfcAsymStatus := ""
 
 		// Query port status from APPL_DB
@@ -614,21 +796,104 @@ func getInterfaceStatus(options sdc.OptionMap) ([]byte, error) {
 			portPfcAsymStatus = fmt.Sprint(data["pfc_asym"])
 		}
 
-		portOperSpeed = getPortOperSpeed(port)
-		portOpticsType = getPortOptics(port)
+		interfaceStatus = append(interfaceStatus, map[string]string{
+			"Interface": port,
+			"Lanes":     portLanesStatus,
+			"Speed":     portOperSpeed,
+			"MTU":       portMtuStatus,
+			"FEC":       portFecStatus,
+			"Alias":     portAlias,
+			"Vlan":      portMode,
+			"Oper":      operStatus,
+			"Admin":     adminStatus,
+			"Type":      portOpticsType,
+			"Asym":      portPfcAsymStatus,
+		})
+	}
+
+	// Get status of portchannel interfaces
+	for i := range portchannels {
+		port := portchannels[i]
+		portLanesStatus := ""
+		portOperSpeed := poSpeedMap[port]
+		portMtuStatus := ""
+		portFecStatus := ""
+		portAlias := ""
+		portMode := poModeMap[port]
+		operStatus := ""
+		adminStatus := ""
+		portOpticsType := getPortOptics(port)
+		portPfcAsymStatus := ""
+
+		// Query portchannel status from APPL_DB
+		queries := [][]string{
+			{"APPL_DB", AppDBPortChannelTable, port},
+		}
+		data, err := GetMapFromQueries(queries)
+		if err != nil {
+			log.Errorf("Failed to get status for portchannel %s: %v", port, err)
+			return nil, err
+		}
+
+		// Query portchannel config from CONFIG_DB
+		queries = [][]string{
+			{"CONFIG_DB", ConfigDBPortChannelTable, port},
+		}
+		config, err := GetMapFromQueries(queries)
+		if err != nil {
+			log.Errorf("Failed to get status for portchannel %s: %v", port, err)
+			return nil, err
+		}
+
+		// parse all fields from APP_DB status data
+		if _, ok := data["lanes"]; !ok {
+			portLanesStatus = "N/A"
+		} else {
+			portLanesStatus = fmt.Sprint(data["lanes"])
+		}
+		if _, ok := config["mtu"]; !ok {
+			portMtuStatus = "N/A"
+		} else {
+			portMtuStatus = fmt.Sprint(config["mtu"])
+		}
+		if _, ok := data["fec"]; !ok {
+			portFecStatus = "N/A"
+		} else {
+			portFecStatus = fmt.Sprint(data["fec"])
+		}
+		if _, ok := data["alias"]; !ok {
+			portAlias = "N/A"
+		} else {
+			portAlias = fmt.Sprint(data["alias"])
+		}
+		if _, ok := data["oper_status"]; !ok {
+			operStatus = "N/A"
+		} else {
+			operStatus = fmt.Sprint(data["oper_status"])
+		}
+		if _, ok := data["admin_status"]; !ok {
+			adminStatus = "N/A"
+		} else {
+			adminStatus = fmt.Sprint(data["admin_status"])
+		}
+		if _, ok := data["pfc_asym"]; !ok {
+			portPfcAsymStatus = "N/A"
+		} else {
+			portPfcAsymStatus = fmt.Sprint(data["pfc_asym"])
+		}
 
 		interfaceStatus = append(interfaceStatus, map[string]string{
-			"Interface":   port,
-			"Lanes":       portLanesStatus,
-			"Speed":       portOperSpeed,
-			"MTU":         portMtuStatus,
-			"FEC":         portFecStatus,
-			"Alias":       portAlias,
-			"Vlan":        vlan,
-			"Oper":        operStatus,
-			"Admin":       adminStatus,
-			"Optics Type": portOpticsType,
-			"Asym":        portPfcAsymStatus,
+			"Interface": port,
+			"Lanes":     portLanesStatus,
+			"Speed":     portOperSpeed,
+			"MTU":       portMtuStatus,
+			"FEC":       portFecStatus,
+			"Alias":     portAlias,
+			"Vlan":      portMode,
+			"Oper":      operStatus,
+			"Admin":     adminStatus,
+			"Type":      portOpticsType,
+			"Asym":      portPfcAsymStatus,
 		})
 	}
 

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -300,7 +300,7 @@ func getInterfaceErrors(options sdc.OptionMap) ([]byte, error) {
 func getIntfsFromConfigDB(intf string) ([]string, error) {
 	// Get the list of ports from the SONiC CONFIG_DB
 	queries := [][]string{
-		{"CONFIG_DB", "PORT"},
+		{"CONFIG_DB", ConfigDBPortTable},
 	}
 	portTable, err := GetMapFromQueries(queries)
 	if err != nil {

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -13,6 +13,7 @@ import (
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
+const ConfigDBPortTable = "PORT"
 const AppDBPortTable = "PORT_TABLE"
 const StateDBPortTable = "PORT_TABLE"
 const ConfigDBPortChannelTable = "PORTCHANNEL"

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -15,6 +15,8 @@ import (
 
 const AppDBPortTable = "PORT_TABLE"
 const StateDBPortTable = "PORT_TABLE"
+const ConfigDBPortChannelTable = "PORTCHANNEL"
+const AppDBPortChannelTable = "LAG_TABLE"
 
 const (
 	dbIndex    = 0 // The first index for a query will be the DB

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -76,4 +76,10 @@ func init() {
 		sdc.UnimplementedOption(showCmdOptionFetchFromHW),
 		showCmdOptionInterface,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "status"},
+		getInterfaceStatus,
+		nil,
+		showCmdOptionInterface
+	)
 }

--- a/testdata/CONFIG_DB.json
+++ b/testdata/CONFIG_DB.json
@@ -1,0 +1,59 @@
+{
+  "PORT|Ethernet0": {
+    "admin_status": "up",
+    "alias": "etp0",
+    "description": "ARISTA01T1:Ethernet1",
+    "fec": "rs",
+    "index": "0",
+    "lanes": "2304,2305,2306,2307",
+    "mtu": "9100",
+    "pfc_asym": "off",
+    "speed": "100000",
+    "tpid": "0x8100"
+  },
+  "PORT|Ethernet40": {
+    "admin_status": "up",
+    "alias": "etp10",
+    "description": "Servers4:eth0",
+    "fec": "rs",
+    "index": "10",
+    "lanes": "2048,2049,2050,2051",
+    "mtu": "9100",
+    "pfc_asym": "off",
+    "speed": "100000",
+    "tpid": "0x8100"
+  },
+  "PORT|Ethernet80": {
+    "admin_status": "up",
+    "alias": "etp20",
+    "description": "ARISTA04T1:Ethernet1",
+    "fec": "rs",
+    "index": "20",
+    "lanes": "2568,2569,2570,2571",
+    "mtu": "9100",
+    "pfc_asym": "off",
+    "speed": "100000",
+    "tpid": "0x8100"
+  },
+  "PORT|Ethernet120": {
+    "admin_status": "up",
+    "alias": "etp30",
+    "description": "Servers4:eth1",
+    "fec": "rs",
+    "index": "20",
+    "lanes": "2668,2669,2670,2671",
+    "mtu": "9100",
+    "pfc_asym": "off",
+    "speed": "100000",
+    "tpid": "0x8100"
+  },
+  "PORTCHANNEL|PortChannel1": {
+    "admin_status": "up",
+    "lacp_key": "auto",
+    "mtu": "9100",
+    "tpid": "0x8100"
+  },
+  "PORTCHANNEL_MEMBER|PortChannel1|Ethernet0": {},
+  "PORTCHANNEL_MEMBER|PortChannel1|Ethernet40": {},
+  "VLAN_MEMBER|Vlan1|Ethernet120": {}
+}

--- a/testdata/STATE_DB.json
+++ b/testdata/STATE_DB.json
@@ -1,0 +1,65 @@
+{
+  "PORT_TABLE|Ethernet0": {
+    "state": "ok",
+    "netdev_oper_status": "up",
+    "admin_status": "up",
+    "mtu": "9100",
+    "host_tx_ready": "true",
+    "supported_speeds": "200000,100000,50000,40000,25000,10000,1000",
+    "supported_fecs": "none,rs,fc,auto",
+    "NPU_SI_SETTINGS_SYNC_STATUS": "NPU_SI_SETTINGS_DEFAULT",
+    "rmt_adv_speeds": "N/A",
+    "speed": "200000",
+    "fec": "rs"
+  },
+  "PORT_TABLE|Ethernet40": {
+    "state": "ok",
+    "netdev_oper_status": "up",
+    "admin_status": "up",
+    "mtu": "9100",
+    "host_tx_ready": "true",
+    "supported_speeds": "200000,100000,50000,40000,25000,10000,1000",
+    "supported_fecs": "none,rs,fc,auto",
+    "NPU_SI_SETTINGS_SYNC_STATUS": "NPU_SI_SETTINGS_DEFAULT",
+    "rmt_adv_speeds": "N/A",
+    "speed": "200000"
+  },
+  "PORT_TABLE|Ethernet80": {
+    "state": "ok",
+    "netdev_oper_status": "up",
+    "admin_status": "up",
+    "mtu": "9100",
+    "host_tx_ready": "true",
+    "supported_speeds": "200000,100000,50000,40000,25000,10000,1000",
+    "supported_fecs": "none,rs,fc,auto",
+    "NPU_SI_SETTINGS_SYNC_STATUS": "NPU_SI_SETTINGS_DEFAULT",
+    "rmt_adv_speeds": "N/A",
+    "speed": "200000",
+    "fec": "rs"
+  },
+  "PORT_TABLE|Ethernet120": {
+    "state": "ok",
+    "netdev_oper_status": "up",
+    "admin_status": "up",
+    "mtu": "9100",
+    "host_tx_ready": "true",
+    "supported_speeds": "200000,100000,50000,40000,25000,10000,1000",
+    "supported_fecs": "none,rs,fc,auto",
+    "NPU_SI_SETTINGS_SYNC_STATUS": "NPU_SI_SETTINGS_DEFAULT",
+    "rmt_adv_speeds": "N/A",
+    "speed": "200000",
+    "fec": "rs"
+  },
+  "TRANSCEIVER_INFO|Ethernet0": {
+    "type": "SFP",
+    "serial": "DEF0000000"
+  },
+  "TRANSCEIVER_INFO|Ethernet40": {
+    "type": "SFP",
+    "serial": "ABC123456"
+  },
+  "TRANSCEIVER_INFO|Ethernet80": {
+    "type": "SFP",
+    "serial": "XYZ987654"
+  }
+}


### PR DESCRIPTION
This PR is to implement support for sonic CLI "show interface status". Since this support is targeting a particular use case, so it currently does not allow querying status of VLAN subinterfaces. Besides, this support does not query sonic_platform package for cable info because of limitations of Golang.