### PR TITLE
Add show mmu command

### DIFF
--- a/gnmi_server/mmu_cli_test.go
+++ b/gnmi_server/mmu_cli_test.go
@@ -1,0 +1,157 @@
+package gnmi
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestShowMmu_HappyPath(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// Load CONFIG_DB datasets
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_DEFAULT_LOSSLESS_BUFFER_PARAMETER.txt")
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_BUFFER_POOL.txt")
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_BUFFER_PROFILE.txt")
+
+	textPbPath := `elem: <name: "mmu" >`
+
+	// Expected JSON (order-insensitive map compare enabled by valTest=true)
+	expected := []byte(`{
+        "losslessTrafficPatterns": {
+            "pattern": { "field1": "value1" }
+        },
+        "pools": {
+            "egress_lossless_pool": { "mode":"static","size":"164075364","type":"egress" },
+            "ingress_lossless_pool": { "mode":"dynamic","size":"164075364","type":"ingress","xoff":"20181824" }
+        },
+        "profiles": {
+            "egress_lossless_profile": { "pool":"egress_lossless_pool","size":"0","static_th":"165364160" },
+            "egress_lossy_profile": { "pool":"egress_lossless_pool","size":"1778","dynamic_th":"0" },
+            "ingress_lossy_profile": { "pool":"ingress_lossless_pool","size":"0","static_th":"165364160" }
+        }
+    }`)
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+}
+
+func TestShowMmu_EmptyConfigDb(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// No datasets loaded in CONFIG_DB -> response is {}
+	textPbPath := `elem: <name: "mmu" >`
+	expected := []byte(`{}`)
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+}
+
+func TestShowMmu_PartialOnlyPools(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// Load only BUFFER_POOL table
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_BUFFER_POOL.txt")
+
+	textPbPath := `elem: <name: "mmu" >`
+	expected := []byte(`{
+        "pools": {
+            "egress_lossless_pool": { "mode":"static","size":"164075364","type":"egress" },
+            "ingress_lossless_pool": { "mode":"dynamic","size":"164075364","type":"ingress","xoff":"20181824" }
+        }
+    }`)
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+}
+
+func TestShowMmu_VerboseTotals(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// Load CONFIG_DB datasets for pools + profiles (+ optional default lossless params)
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_DEFAULT_LOSSLESS_BUFFER_PARAMETER.txt")
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_BUFFER_POOL.txt")
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_BUFFER_PROFILE.txt")
+
+	// Pass verbose=true as an option on the "mmu" elem
+	textPbPath := `
+        elem: <name: "mmu" key: { key: "verbose" value: "true" } >
+    `
+
+	expected := []byte(`{
+        "losslessTrafficPatterns": {
+            "pattern": { "field1": "value1" }
+        },
+        "pools": {
+            "egress_lossless_pool": { "mode":"static","size":"164075364","type":"egress" },
+            "ingress_lossless_pool": { "mode":"dynamic","size":"164075364","type":"ingress","xoff":"20181824" }
+        },
+        "profiles": {
+            "egress_lossless_profile": { "pool":"egress_lossless_pool","size":"0","static_th":"165364160" },
+            "egress_lossy_profile": { "pool":"egress_lossless_pool","size":"1778","dynamic_th":"0" },
+            "ingress_lossy_profile": { "pool":"ingress_lossless_pool","size":"0","static_th":"165364160" }
+        },
+        "totals": { "pools": 2, "profiles": 3 }
+    }`)
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+}

--- a/gnmi_server/mmu_cli_test.go
+++ b/gnmi_server/mmu_cli_test.go
@@ -2,10 +2,13 @@ package gnmi
 
 import (
 	"crypto/tls"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
+	sc "github.com/sonic-net/sonic-gnmi/show_client"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -154,4 +157,36 @@ func TestShowMmu_VerboseTotals(t *testing.T) {
         "totals": { "pools": 2, "profiles": 3 }
     }`)
 	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+}
+
+func TestShowMmu_ErrorOnLossless(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	var calls int
+	patches := gomonkey.ApplyFunc(sc.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("error when read table DEFAULT_LOSSLESS_BUFFER_PARAMETER")
+		}
+		return map[string]interface{}{}, nil
+	})
+	defer patches.Reset()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	textPbPath := `elem: <name: "mmu" >`
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.NotFound, nil, false)
 }

--- a/gnmi_server/mmu_cli_test.go
+++ b/gnmi_server/mmu_cli_test.go
@@ -190,3 +190,79 @@ func TestShowMmu_ErrorOnLossless(t *testing.T) {
 	textPbPath := `elem: <name: "mmu" >`
 	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.NotFound, nil, false)
 }
+
+func TestShowMmu_ErrorOnPools(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	var calls int
+	patches := gomonkey.ApplyFunc(sc.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+		calls++
+		switch calls {
+		case 1:
+			// first call: lossless table succeeds (empty map fine)
+			return map[string]interface{}{}, nil
+		case 2:
+			// second call: pools table error
+			return nil, fmt.Errorf("error when read table BUFFER_POOL")
+		default:
+			return map[string]interface{}{}, nil
+		}
+	})
+	defer patches.Reset()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	textPbPath := `elem: <name: "mmu" >`
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.NotFound, nil, false)
+}
+
+func TestShowMmu_ErrorOnProfiles(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	var calls int
+	patches := gomonkey.ApplyFunc(sc.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+		calls++
+		switch calls {
+		case 1: // lossless ok
+			return map[string]interface{}{}, nil
+		case 2: // pools ok
+			return map[string]interface{}{}, nil
+		case 3: // profiles error
+			return nil, fmt.Errorf("error when read table BUFFER_PROFILE")
+		default:
+			return map[string]interface{}{}, nil
+		}
+	})
+	defer patches.Reset()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	textPbPath := `elem: <name: "mmu" >`
+	runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.NotFound, nil, false)
+}

--- a/show_client/mmu_cli.go
+++ b/show_client/mmu_cli.go
@@ -71,19 +71,19 @@ const (
 //  5. "type"
 //  6. "egress"
 func getMmuConfig(options sdc.OptionMap) ([]byte, error) {
-	lossless, err := getTableAsNestedMap("CONFIG_DB", cfgTableDefaultLossless)
+	lossless, err := getTableAsNestedMap(ConfigDb, cfgTableDefaultLossless)
 	if err != nil {
-		log.Errorf("Failed to read %s: %v", cfgTableDefaultLossless, err)
+		log.Errorf("[show mmu]|Failed to read %s: %v", cfgTableDefaultLossless, err)
 		return nil, err
 	}
-	pools, err := getTableAsNestedMap("CONFIG_DB", cfgTableBufferPool)
+	pools, err := getTableAsNestedMap(ConfigDb, cfgTableBufferPool)
 	if err != nil {
-		log.Errorf("Failed to read %s: %v", cfgTableBufferPool, err)
+		log.Errorf("[show mmu]|Failed to read %s: %v", cfgTableBufferPool, err)
 		return nil, err
 	}
-	profiles, err := getTableAsNestedMap("CONFIG_DB", cfgTableBufferProfile)
+	profiles, err := getTableAsNestedMap(ConfigDb, cfgTableBufferProfile)
 	if err != nil {
-		log.Errorf("Failed to read %s: %v", cfgTableBufferProfile, err)
+		log.Errorf("[show mmu]|Failed to read %s: %v", cfgTableBufferProfile, err)
 		return nil, err
 	}
 
@@ -117,6 +117,8 @@ func getTableAsNestedMap(db string, table string) (map[string]map[string]interfa
 		// The value is also a map, e.g. key is mode, value is static
 		if row, ok := v.(map[string]interface{}); ok {
 			out[k] = row
+		} else {
+			log.Errorf("[show mmu]|Unexpected value for %s: %v", k, v)
 		}
 	}
 	return out, nil

--- a/show_client/mmu_cli.go
+++ b/show_client/mmu_cli.go
@@ -1,0 +1,123 @@
+package show_client
+
+import (
+	"encoding/json"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+type MmuTotals struct {
+	Pools    int `json:"pools"`
+	Profiles int `json:"profiles"`
+}
+
+type MmuConfigResponse struct {
+	// renamed JSON keys and fields
+	LosslessTrafficPatterns map[string]map[string]interface{} `json:"losslessTrafficPatterns,omitempty"`
+	Pools                   map[string]map[string]interface{} `json:"pools,omitempty"`
+	Profiles                map[string]map[string]interface{} `json:"profiles,omitempty"`
+	Totals                  *MmuTotals                        `json:"totals,omitempty"`
+}
+
+const (
+	// CONFIG_DB(cfg) table names
+	cfgTableDefaultLossless = "DEFAULT_LOSSLESS_BUFFER_PARAMETER"
+	cfgTableBufferPool      = "BUFFER_POOL"
+	cfgTableBufferProfile   = "BUFFER_PROFILE"
+)
+
+// getMmuConfig implements Python `mmuconfig -l` in Go by reading CONFIG_DB tables.
+// https://github.com/Azure/sonic-utilities.msft/blob/3cb0eb2402a8da806b7c858eaa7e6be950c92fe3/scripts/mmuconfig#L90
+// Example output:
+// $ show mmu -vv
+// Pool: egress_lossless_pool
+// ----  ---------
+// mode  static
+// size  164075364
+// type  egress
+// ----  ---------
+
+// Pool: ingress_lossless_pool
+// ----  ---------
+// mode  dynamic
+// size  164075364
+// type  ingress
+// xoff  20181824
+// ----  ---------
+
+// Total pools: 2
+
+// The following is the data in redis
+// $ redis-cli -n 4 KEYS 'BUFFER_POOL*'
+//  1. "BUFFER_POOL|ingress_lossless_pool"
+//  2. "BUFFER_POOL|egress_lossless_pool"
+//
+// $ redis-cli -n 4 HGETALL 'BUFFER_POOL|ingress_lossless_pool'
+//  1. "mode"
+//  2. "dynamic"
+//  3. "size"
+//  4. "164075364"
+//  5. "type"
+//  6. "ingress"
+//  7. "xoff"
+//  8. "20181824"
+//
+// $ redis-cli -n 4 HGETALL 'BUFFER_POOL|egress_lossless_pool'
+//  1. "mode"
+//  2. "static"
+//  3. "size"
+//  4. "164075364"
+//  5. "type"
+//  6. "egress"
+func getMmuConfig(options sdc.OptionMap) ([]byte, error) {
+	lossless, err := getTableAsNestedMap("CONFIG_DB", cfgTableDefaultLossless)
+	if err != nil {
+		log.Errorf("Failed to read %s: %v", cfgTableDefaultLossless, err)
+		return nil, err
+	}
+	pools, err := getTableAsNestedMap("CONFIG_DB", cfgTableBufferPool)
+	if err != nil {
+		log.Errorf("Failed to read %s: %v", cfgTableBufferPool, err)
+		return nil, err
+	}
+	profiles, err := getTableAsNestedMap("CONFIG_DB", cfgTableBufferProfile)
+	if err != nil {
+		log.Errorf("Failed to read %s: %v", cfgTableBufferProfile, err)
+		return nil, err
+	}
+
+	resp := MmuConfigResponse{
+		LosslessTrafficPatterns: lossless,
+		Pools:                   pools,
+		Profiles:                profiles,
+	}
+
+	if v, ok := options["verbose"].Bool(); ok && v {
+		resp.Totals = &MmuTotals{
+			Pools:    len(pools),
+			Profiles: len(profiles),
+		}
+	}
+
+	return json.Marshal(resp)
+}
+
+// pls read the comments on getMmuConfig
+func getTableAsNestedMap(db string, table string) (map[string]map[string]interface{}, error) {
+	// Get all keys and values in the table
+	queries := [][]string{{db, table}}
+	msi, err := GetMapFromQueries(queries)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]map[string]interface{}, len(msi))
+	for k, v := range msi {
+		// The value is also a map, e.g. key is mode, value is static
+		if row, ok := v.(map[string]interface{}); ok {
+			out[k] = row
+		}
+	}
+	return out, nil
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -107,6 +107,13 @@ func init() {
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 	)
 	sdc.RegisterCliPath(
+		[]string{"SHOW", "mmu"},
+		getMmuConfig,
+		nil,
+		sdc.UnimplementedOption(showCmdOptionNamespace),
+		showCmdOptionVerbose,
+	)
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "mac", "aging-time"},
 		getMacAgingTime,
 		nil,

--- a/testdata/CONFIG_DB_BUFFER_POOL.txt
+++ b/testdata/CONFIG_DB_BUFFER_POOL.txt
@@ -1,0 +1,13 @@
+{
+  "BUFFER_POOL|ingress_lossless_pool": {
+    "mode": "dynamic",
+    "size": "164075364",
+    "type": "ingress",
+    "xoff": "20181824"
+  },
+  "BUFFER_POOL|egress_lossless_pool": {
+    "mode": "static",
+    "size": "164075364",
+    "type": "egress"
+  }
+}

--- a/testdata/CONFIG_DB_BUFFER_PROFILE.txt
+++ b/testdata/CONFIG_DB_BUFFER_PROFILE.txt
@@ -1,0 +1,17 @@
+{
+  "BUFFER_PROFILE|egress_lossless_profile": {
+    "pool": "egress_lossless_pool",
+    "size": "0",
+    "static_th": "165364160"
+  },
+  "BUFFER_PROFILE|egress_lossy_profile": {
+    "pool": "egress_lossless_pool",
+    "size": "1778",
+    "dynamic_th": "0"
+  },
+  "BUFFER_PROFILE|ingress_lossy_profile": {
+    "pool": "ingress_lossless_pool",
+    "size": "0",
+    "static_th": "165364160"
+  }
+}

--- a/testdata/CONFIG_DB_DEFAULT_LOSSLESS_BUFFER_PARAMETER.txt
+++ b/testdata/CONFIG_DB_DEFAULT_LOSSLESS_BUFFER_PARAMETER.txt
@@ -1,0 +1,5 @@
+{
+  "DEFAULT_LOSSLESS_BUFFER_PARAMETER|pattern": {
+    "field1": "value1"
+  }
+}


### PR DESCRIPTION
**Why I did it**
Add support for show headroom_pool watermark and show headroom_pool persistent-watermark

This PR will add the implementation of a new data path "SHOW" that will allow clients to query PATHS similar to show commands that are executed on the host.

**How I did it**
Added a new SHOW client that supports GET operations only and can support DB reads.
And unify the code for command buffer_pool  and headroom_pool 

**How to verify it**
UT and manually run

```
 :/# gnmi_get -xpath_target SHOW -xpath mmu -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "mmu"
  >
>
encoding: JSON_IETF



== getResponse:
notification: <
  timestamp: 1756192089285039375
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "mmu"
      >
    >
    val: <
      json_ietf_val: "{\"pools\":{\"egress_lossless_pool\":{\"mode\":\"static\",\"size\":\"164075364\",\"type\":\"egress\"},\"ingress_lossless_pool\":{\"mode\":\"dynamic\",\"size\":\"164075364\",\"type\":\"ingress\",\"xoff\":\"20181824\"}},\"profiles\":{\"egress_lossless_profile\":{\"pool\":\"egress_lossless_pool\",\"size\":\"0\",\"static_th\":\"165364160\"},\"egress_lossy_profile\":{\"dynamic_th\":\"0\",\"pool\":\"egress_lossless_pool\",\"size\":\"1778\"},\"ingress_lossy_profile\":{\"pool\":\"ingress_lossless_pool\",\"size\":\"0\",\"static_th\":\"165364160\"},\"pg_lossless_400000_5m_profile\":{\"dynamic_th\":\"0\",\"pool\":\"ingress_lossless_pool\",\"size\":\"18796\",\"xoff\":\"393192\",\"xon\":\"0\",\"xon_offset\":\"3556\"}}}"
    >
  >
>

```
```

 :/# gnmi_get -xpath_target SHOW -xpath mmu[verbose=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "mmu"
    key: <
      key: "verbose"
      value: "true"
    >
  >
>
encoding: JSON_IETF



== getResponse:
notification: <
  timestamp: 1756192098242278333
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "mmu"
        key: <
          key: "verbose"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"pools\":{\"egress_lossless_pool\":{\"mode\":\"static\",\"size\":\"164075364\",\"type\":\"egress\"},\"ingress_lossless_pool\":{\"mode\":\"dynamic\",\"size\":\"164075364\",\"type\":\"ingress\",\"xoff\":\"20181824\"}},\"profiles\":{\"egress_lossless_profile\":{\"pool\":\"egress_lossless_pool\",\"size\":\"0\",\"static_th\":\"165364160\"},\"egress_lossy_profile\":{\"dynamic_th\":\"0\",\"pool\":\"egress_lossless_pool\",\"size\":\"1778\"},\"ingress_lossy_profile\":{\"pool\":\"ingress_lossless_pool\",\"size\":\"0\",\"static_th\":\"165364160\"},\"pg_lossless_400000_5m_profile\":{\"dynamic_th\":\"0\",\"pool\":\"ingress_lossless_pool\",\"size\":\"18796\",\"xoff\":\"393192\",\"xon\":\"0\",\"xon_offset\":\"3556\"}},\"totals\":{\"pools\":2,\"profiles\":4}}"
```

```
 :~$ show mmu -vv
Pool: egress_lossless_pool
----  ---------
mode  static
size  164075364
type  egress
----  ---------

Pool: ingress_lossless_pool
----  ---------
mode  dynamic
size  164075364
type  ingress
xoff  20181824
----  ---------

Total pools: 2


Profile: egress_lossless_profile
---------  --------------------
pool       egress_lossless_pool
size       0
static_th  165364160
---------  --------------------

Profile: egress_lossy_profile
----------  --------------------
dynamic_th  0
pool        egress_lossless_pool
size        1778
----------  --------------------

Profile: ingress_lossy_profile
---------  ---------------------
pool       ingress_lossless_pool
size       0
static_th  165364160
---------  ---------------------

Profile: pg_lossless_400000_5m_profile
----------  ---------------------
dynamic_th  0
pool        ingress_lossless_pool
size        18796
xoff        393192
xon         0
xon_offset  3556
----------  ---------------------

Total profiles: 4
```

```
 :~$ show mmu
Pool: egress_lossless_pool
----  ---------
mode  static
size  164075364
type  egress
----  ---------

Pool: ingress_lossless_pool
----  ---------
mode  dynamic
size  164075364
type  ingress
xoff  20181824
----  ---------

Profile: egress_lossless_profile
---------  --------------------
pool       egress_lossless_pool
size       0
static_th  165364160
---------  --------------------

Profile: egress_lossy_profile
----------  --------------------
dynamic_th  0
pool        egress_lossless_pool
size        1778
----------  --------------------

Profile: ingress_lossy_profile
---------  ---------------------
pool       ingress_lossless_pool
size       0
static_th  165364160
---------  ---------------------

Profile: pg_lossless_400000_5m_profile
----------  ---------------------
dynamic_th  0
pool        ingress_lossless_pool
size        18796
xoff        393192
xon         0
xon_offset  3556
----------  ---------------------
```
