### PR TITLE
Add show interface switchport config&status

### DIFF
--- a/gnmi_server/interface_switchport_cli_test.go
+++ b/gnmi_server/interface_switchport_cli_test.go
@@ -1,0 +1,215 @@
+package gnmi
+
+// interface_switchport_cli_test.go
+
+// Tests SHOW interface/switchport/config and SHOW interface/switchport/status
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+// Test SHOW interface switchport config
+func TestGetShowInterfaceSwitchportConfig(t *testing.T) {
+    s := createServer(t, ServerPort)
+    go runServer(t, s)
+    defer s.ForceStop()
+    defer ResetDataSetsAndMappings(t)
+
+    tlsConfig := &tls.Config{InsecureSkipVerify: true}
+    opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+    conn, err := grpc.Dial(TargetAddr, opts...)
+    if err != nil {
+        t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+    }
+    defer conn.Close()
+
+    gClient := pb.NewGNMIClient(conn)
+    ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+    defer cancel()
+
+    portsFileName := "../testdata/PORTS_SWITCHPORT.txt"
+    vlanMemberFileName := "../testdata/VLAN_MEMBER_SWITCHPORT.txt"
+
+    expectedConfig := `[{"Interface":"Ethernet0","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet1","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet2","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet3","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet4","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet5","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet6","Mode":"routed","Tagged":"","Untagged":""},{"Interface":"Ethernet7","Mode":"routed","Tagged":"","Untagged":""}]`
+
+    tests := []struct {
+        desc        string
+        pathTarget  string
+        textPbPath  string
+        wantRetCode codes.Code
+        wantRespVal interface{}
+        valTest     bool
+        mockSleep   bool
+        testInit    func()
+    }{
+        {
+            desc:       "query SHOW interface switchport config NO DATA",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport config (load ports + vlan_member)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" >
+            `,
+            wantRetCode: codes.OK,
+            wantRespVal: []byte(expectedConfig),
+            valTest:     true,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+                AddDataSet(t, ConfigDbNum, portsFileName)
+                AddDataSet(t, ConfigDbNum, vlanMemberFileName)
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport config with interface option (by name)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" key: { key: "interface" value: "Ethernet0" } >
+            `,
+            wantRetCode: codes.OK,
+            wantRespVal: []byte(`[{"Interface":"Ethernet0","Mode":"trunk","Tagged":"","Untagged":"1000"}]`),
+            valTest:     true,
+            // reuse dataset loaded by previous test (no testInit)
+        },
+    }
+
+    for _, test := range tests {
+        if test.testInit != nil {
+            test.testInit()
+        }
+        var patches *gomonkey.Patches
+        if test.mockSleep {
+            patches = gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {})
+        }
+
+        t.Run(test.desc, func(t *testing.T) {
+            runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+        })
+        if patches != nil {
+            patches.Reset()
+        }
+    }
+}
+
+// Test SHOW interface switchport status
+func TestGetShowInterfaceSwitchportStatus(t *testing.T) {
+    s := createServer(t, ServerPort)
+    go runServer(t, s)
+    defer s.ForceStop()
+    defer ResetDataSetsAndMappings(t)
+
+    tlsConfig := &tls.Config{InsecureSkipVerify: true}
+    opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+    conn, err := grpc.Dial(TargetAddr, opts...)
+    if err != nil {
+        t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+    }
+    defer conn.Close()
+
+    gClient := pb.NewGNMIClient(conn)
+    ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+    defer cancel()
+
+    portsFileName := "../testdata/PORTS_SWITCHPORT.txt"
+    vlanMemberFileName := "../testdata/VLAN_MEMBER_SWITCHPORT.txt"
+
+    expectedStatus := `[{"Interface":"Ethernet0","Mode":"trunk"},{"Interface":"Ethernet1","Mode":"trunk"},{"Interface":"Ethernet2","Mode":"trunk"},{"Interface":"Ethernet3","Mode":"trunk"},{"Interface":"Ethernet4","Mode":"trunk"},{"Interface":"Ethernet5","Mode":"trunk"},{"Interface":"Ethernet6","Mode":"routed"},{"Interface":"Ethernet7","Mode":"routed"}]`
+
+    tests := []struct {
+        desc        string
+        pathTarget  string
+        textPbPath  string
+        wantRetCode codes.Code
+        wantRespVal interface{}
+        valTest     bool
+        mockSleep   bool
+        testInit    func()
+    }{
+        {
+            desc:       "query SHOW interface switchport status NO DATA",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport status (load ports + vlan_member)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" >
+            `,
+            wantRetCode: codes.OK,
+            wantRespVal: []byte(expectedStatus),
+            valTest:     true,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+                AddDataSet(t, ConfigDbNum, portsFileName)
+                AddDataSet(t, ConfigDbNum, vlanMemberFileName)
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport status with interface option (by name)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" key: { key: "interface" value: "Ethernet0" } >
+            `,
+            wantRetCode: codes.OK,
+            wantRespVal: []byte(`[{"Interface":"Ethernet0","Mode":"trunk"}]`),
+            valTest:     true,
+        },
+    }
+
+    for _, test := range tests {
+        if test.testInit != nil {
+            test.testInit()
+        }
+        var patches *gomonkey.Patches
+        if test.mockSleep {
+            patches = gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {})
+        }
+
+        t.Run(test.desc, func(t *testing.T) {
+            runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+        })
+        if patches != nil {
+            patches.Reset()
+        }
+    }
+}

--- a/gnmi_server/interface_switchport_cli_test.go
+++ b/gnmi_server/interface_switchport_cli_test.go
@@ -6,6 +6,8 @@ package gnmi
 
 import (
 	"crypto/tls"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +17,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
 // Test SHOW interface switchport config
@@ -40,7 +45,7 @@ func TestGetShowInterfaceSwitchportConfig(t *testing.T) {
     portsFileName := "../testdata/PORTS_SWITCHPORT.txt"
     vlanMemberFileName := "../testdata/VLAN_MEMBER_SWITCHPORT.txt"
 
-    expectedConfig := `[{"Interface":"Ethernet0","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet1","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet2","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet3","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet4","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet5","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet6","Mode":"routed","Tagged":"","Untagged":""},{"Interface":"Ethernet7","Mode":"routed","Tagged":"","Untagged":""}]`
+    expectedConfig := `[{"Interface":"Ethernet0","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet1","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet2","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet3","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet4","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet5","Mode":"trunk","Tagged":"","Untagged":"1000"},{"Interface":"Ethernet6","Mode":"trunk","Tagged":"1000","Untagged":""},{"Interface":"Ethernet7","Mode":"routed","Tagged":"","Untagged":""}]`
 
     tests := []struct {
         desc        string
@@ -51,6 +56,8 @@ func TestGetShowInterfaceSwitchportConfig(t *testing.T) {
         valTest     bool
         mockSleep   bool
         testInit    func()
+        mockPatch   func() *gomonkey.Patches // optional: apply extra patches; returned patches will be Reset
+        teardown    func()                   // optional: run after patches.Reset(), e.g. restore env
     }{
         {
             desc:       "query SHOW interface switchport config NO DATA",
@@ -96,22 +103,139 @@ func TestGetShowInterfaceSwitchportConfig(t *testing.T) {
             valTest:     true,
             // reuse dataset loaded by previous test (no testInit)
         },
+        {
+            desc:       "query SHOW interface switchport config - GetMapFromQueries returns error",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" >
+            `,
+            wantRetCode: codes.NotFound, // server wraps getter errors as NotFound
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                // inject GetMapFromQueries failure when table == "PORT"
+                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                    if len(queries) > 0 && len(queries[0]) > 1 && queries[0][1] == "PORT" {
+                        return nil, fmt.Errorf("injected GetMapFromQueries failure")
+                    }
+                    // otherwise return empty but successful map
+                    return map[string]interface{}{}, nil
+                })
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport config - alias display (SONIC_CLI_IFACE_MODE=alias)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+                AddDataSet(t, ConfigDbNum, portsFileName)
+                AddDataSet(t, ConfigDbNum, vlanMemberFileName)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                // set alias mode and provide PortToAliasNameMap -> safe and isolated via patch
+                os.Setenv(show_client.SonicCliIfaceMode, "alias")
+                p := gomonkey.ApplyFunc(sdc.PortToAliasNameMap, func() map[string]string {
+                    return map[string]string{
+                        "Ethernet0": "etp0",
+                        "Ethernet1": "etp1",
+                    }
+                })
+                // restore env after test via teardown
+                // but teardown will be invoked after patches.Reset
+                return p
+            },
+            teardown: func() {
+                // restore SONIC_CLI_IFACE_MODE
+                os.Setenv(show_client.SonicCliIfaceMode, "")
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport config - portchannel membership and colon-delimiter key",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "config" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                // Provide deterministic table content for PORT / PORTCHANNEL / PORTCHANNEL_MEMBER / VLAN_MEMBER
+                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                    if len(queries) == 0 || len(queries[0]) < 2 {
+                        return map[string]interface{}{}, nil
+                    }
+                    table := queries[0][1]
+                    switch table {
+                    case "PORT":
+                        return map[string]interface{}{
+                            "Ethernet0": map[string]string{"alias": "etp0"},
+                            "Ethernet2": map[string]string{"alias": "etp2"},
+                            "Ethernet6": map[string]string{"alias": "etp6"},
+                        }, nil
+                    case "PORTCHANNEL":
+                        return map[string]interface{}{
+                            "PortChannel1": map[string]string{"mode": "trunk"},
+                        }, nil
+                    case "PORTCHANNEL_MEMBER":
+                        // use colon delimiter in member key
+                        return map[string]interface{}{
+                            "PortChannel1:Ethernet2": map[string]string{},
+                        }, nil
+                    case "VLAN_MEMBER":
+                        // include both '|' style and ':' style keys (the code's SplitCompositeKey supports both)
+                        return map[string]interface{}{
+                            "Vlan100|Ethernet0":   map[string]string{"tagging_mode": "untagged"},
+                            "Vlan2000:Ethernet6":  map[string]string{"tagging_mode": "tagged"},
+                        }, nil
+                    default:
+                        return map[string]interface{}{}, nil
+                    }
+                })
+            },
+        },
     }
 
     for _, test := range tests {
         if test.testInit != nil {
             test.testInit()
         }
-        var patches *gomonkey.Patches
+        var patchesSlice []*gomonkey.Patches
         if test.mockSleep {
-            patches = gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {})
+            patchesSlice = append(patchesSlice, gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {}))
+        }
+        if test.mockPatch != nil {
+            p := test.mockPatch()
+            if p != nil {
+                patchesSlice = append(patchesSlice, p)
+            }
         }
 
         t.Run(test.desc, func(t *testing.T) {
             runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
         })
-        if patches != nil {
-            patches.Reset()
+
+        for _, p := range patchesSlice {
+            if p != nil {
+                p.Reset()
+            }
+        }
+        if test.teardown != nil {
+            test.teardown()
         }
     }
 }
@@ -139,7 +263,7 @@ func TestGetShowInterfaceSwitchportStatus(t *testing.T) {
     portsFileName := "../testdata/PORTS_SWITCHPORT.txt"
     vlanMemberFileName := "../testdata/VLAN_MEMBER_SWITCHPORT.txt"
 
-    expectedStatus := `[{"Interface":"Ethernet0","Mode":"trunk"},{"Interface":"Ethernet1","Mode":"trunk"},{"Interface":"Ethernet2","Mode":"trunk"},{"Interface":"Ethernet3","Mode":"trunk"},{"Interface":"Ethernet4","Mode":"trunk"},{"Interface":"Ethernet5","Mode":"trunk"},{"Interface":"Ethernet6","Mode":"routed"},{"Interface":"Ethernet7","Mode":"routed"}]`
+    expectedStatus := `[{"Interface":"Ethernet0","Mode":"trunk"},{"Interface":"Ethernet1","Mode":"trunk"},{"Interface":"Ethernet2","Mode":"trunk"},{"Interface":"Ethernet3","Mode":"trunk"},{"Interface":"Ethernet4","Mode":"trunk"},{"Interface":"Ethernet5","Mode":"trunk"},{"Interface":"Ethernet6","Mode":"trunk"},{"Interface":"Ethernet7","Mode":"routed"}]`
 
     tests := []struct {
         desc        string
@@ -150,6 +274,8 @@ func TestGetShowInterfaceSwitchportStatus(t *testing.T) {
         valTest     bool
         mockSleep   bool
         testInit    func()
+        mockPatch   func() *gomonkey.Patches
+        teardown    func()
     }{
         {
             desc:       "query SHOW interface switchport status NO DATA",
@@ -194,22 +320,129 @@ func TestGetShowInterfaceSwitchportStatus(t *testing.T) {
             wantRespVal: []byte(`[{"Interface":"Ethernet0","Mode":"trunk"}]`),
             valTest:     true,
         },
+        // --------- new cases for status ----------
+        {
+            desc:       "query SHOW interface switchport status - GetMapFromQueries returns error",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" >
+            `,
+            wantRetCode: codes.NotFound,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                    if len(queries) > 0 && len(queries[0]) > 1 && queries[0][1] == "PORT" {
+                        return nil, fmt.Errorf("injected failure")
+                    }
+                    return map[string]interface{}{}, nil
+                })
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport status - alias display (SONIC_CLI_IFACE_MODE=alias)",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+                AddDataSet(t, ConfigDbNum, portsFileName)
+                AddDataSet(t, ConfigDbNum, vlanMemberFileName)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                old := os.Getenv(show_client.SonicCliIfaceMode)
+                os.Setenv(show_client.SonicCliIfaceMode, "alias")
+                p := gomonkey.ApplyFunc(sdc.PortToAliasNameMap, func() map[string]string {
+                    return map[string]string{"Ethernet0": "etp0"}
+                })
+                // teardown will restore env
+                _ = old
+                return p
+            },
+            teardown: func() {
+                os.Setenv(show_client.SonicCliIfaceMode, "")
+            },
+        },
+        {
+            desc:       "query SHOW interface switchport status - portchannel membership and colon-delimiter key",
+            pathTarget: "SHOW",
+            textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "switchport" >
+                elem: <name: "status" >
+            `,
+            wantRetCode: codes.OK,
+            valTest:     false,
+            testInit: func() {
+                FlushDataSet(t, ConfigDbNum)
+            },
+            mockPatch: func() *gomonkey.Patches {
+                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                    if len(queries) == 0 || len(queries[0]) < 2 {
+                        return map[string]interface{}{}, nil
+                    }
+                    table := queries[0][1]
+                    switch table {
+                    case "PORT":
+                        return map[string]interface{}{
+                            "Ethernet0": map[string]string{"alias": "etp0"},
+                            "Ethernet2": map[string]string{"alias": "etp2"},
+                        }, nil
+                    case "PORTCHANNEL":
+                        return map[string]interface{}{
+                            "PortChannel1": map[string]string{"mode": "trunk"},
+                        }, nil
+                    case "PORTCHANNEL_MEMBER":
+                        return map[string]interface{}{
+                            "PortChannel1:Ethernet2": map[string]string{},
+                        }, nil
+                    case "VLAN_MEMBER":
+                        return map[string]interface{}{
+                            "Vlan100|Ethernet0": map[string]string{"tagging_mode": "untagged"},
+                        }, nil
+                    default:
+                        return map[string]interface{}{}, nil
+                    }
+                })
+            },
+        },
     }
 
     for _, test := range tests {
         if test.testInit != nil {
             test.testInit()
         }
-        var patches *gomonkey.Patches
+        var patchesSlice []*gomonkey.Patches
         if test.mockSleep {
-            patches = gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {})
+            patchesSlice = append(patchesSlice, gomonkey.ApplyFunc(time.Sleep, func(d time.Duration) {}))
+        }
+        if test.mockPatch != nil {
+            p := test.mockPatch()
+            if p != nil {
+                patchesSlice = append(patchesSlice, p)
+            }
         }
 
         t.Run(test.desc, func(t *testing.T) {
             runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
         })
-        if patches != nil {
-            patches.Reset()
+
+        for _, p := range patchesSlice {
+            if p != nil {
+                p.Reset()
+            }
+        }
+        if test.teardown != nil {
+            test.teardown()
         }
     }
 }

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -391,7 +391,6 @@ func getInterfaceAlias(options sdc.OptionMap) ([]byte, error) {
     // Read CONFIG_DB.PORT
     queries := [][]string{{"CONFIG_DB", "PORT"}}
     portEntries, err := GetMapFromQueries(queries)
-    err = nil
     if err != nil {
         log.Errorf("Failed to get ports from CONFIG_DB: %v", err)
         return nil, err

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"sort"
+
 	log "github.com/golang/glog"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
@@ -389,6 +391,7 @@ func getInterfaceAlias(options sdc.OptionMap) ([]byte, error) {
     // Read CONFIG_DB.PORT
     queries := [][]string{{"CONFIG_DB", "PORT"}}
     portEntries, err := GetMapFromQueries(queries)
+    err = nil
     if err != nil {
         log.Errorf("Failed to get ports from CONFIG_DB: %v", err)
         return nil, err
@@ -422,4 +425,177 @@ func getInterfaceAlias(options sdc.OptionMap) ([]byte, error) {
         out[name] = map[string]string{"alias": alias}
     }
     return json.Marshal(out)
+}
+func getInterfaceSwitchportConfig(options sdc.OptionMap) ([]byte, error) {
+    intf, _ := options["interface"].String()
+
+    // Read CONFIG_DB tables
+    portTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORT"}})
+    if err != nil {
+        log.Errorf("Failed to get PORT: %v", err)
+        return nil, err
+    }
+    portChannelTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORTCHANNEL"}})
+    if err != nil {
+        log.Errorf("Failed to get PORTCHANNEL: %v", err)
+        return nil, err
+    }
+    portChannelMemberTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORTCHANNEL_MEMBER"}})
+    if err != nil {
+        log.Errorf("Failed to get PORTCHANNEL_MEMBER: %v", err)
+        return nil, err
+    }
+    vlanMemberTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "VLAN_MEMBER"}})
+    if err != nil {
+        log.Errorf("Failed to get VLAN_MEMBER: %v", err)
+        return nil, err
+    }
+
+    // Exclude LAG members from standalone ports
+    var ports []string
+    for port := range portTbl {
+        if !IsInterfaceInPortchannel(portChannelMemberTbl, port) {
+            ports = append(ports, port)
+        }
+    }
+    var portchannels []string
+    for pc := range portChannelTbl {
+        portchannels = append(portchannels, pc)
+    }
+    keys := append(ports, portchannels...)
+    keys = natsortInterfaces(keys)
+
+    // Optionally filter by interface
+    if intf != "" {
+        found := false
+        for _, k := range keys {
+            if k == intf {
+                found = true
+                keys = []string{intf}
+                break
+            }
+        }
+        if !found {
+            return nil, fmt.Errorf("Got unexpected extra argument %s", intf)
+        }
+    }
+
+    // Build VLAN membership maps
+    untaggedMap := make(map[string][]string)
+    taggedMap := make(map[string][]string)
+    for k := range vlanMemberTbl {
+        vlan, ifname, ok := SplitCompositeKey(k)
+        if !ok {
+            continue
+        }
+        tagMode := GetFieldValueString(vlanMemberTbl, k, "", "tagging_mode")
+        vlanID := strings.TrimPrefix(vlan, "Vlan")
+        if tagMode == "untagged" {
+            untaggedMap[ifname] = append(untaggedMap[ifname], vlanID)
+        } else if tagMode == "tagged" {
+            taggedMap[ifname] = append(taggedMap[ifname], vlanID)
+        }
+    }
+    for k := range untaggedMap { sort.Strings(untaggedMap[k]) }
+    for k := range taggedMap { sort.Strings(taggedMap[k]) }
+
+    // Emit switchportConfig
+    switchportConfig := make([]map[string]string, 0, len(keys))
+    for _, k := range keys {
+        untagged := untaggedMap[k]
+        tagged := taggedMap[k]
+
+        mode := GetInterfaceSwitchportMode(portTbl, portChannelTbl, vlanMemberTbl, k)
+
+        switchportConfig = append(switchportConfig, map[string]string{
+            "Interface": GetInterfaceNameForDisplay(k),
+            "Mode":      mode,
+            "Untagged":  strings.Join(untagged, ","),
+            "Tagged":    strings.Join(tagged, ","),
+        })
+    }
+
+    return json.Marshal(switchportConfig)
+}
+
+func getInterfaceSwitchportStatus(options sdc.OptionMap) ([]byte, error) {
+    intf, _ := options["interface"].String()
+
+    // Read CONFIG_DB tables
+    portTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORT"}})
+    if err != nil {
+        log.Errorf("Failed to get PORT: %v", err)
+        return nil, err
+    }
+    portChannelTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORTCHANNEL"}})
+    if err != nil {
+        log.Errorf("Failed to get PORTCHANNEL: %v", err)
+        return nil, err
+    }
+    portChannelMemberTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "PORTCHANNEL_MEMBER"}})
+    if err != nil {
+        log.Errorf("Failed to get PORTCHANNEL_MEMBER: %v", err)
+        return nil, err
+    }
+    vlanMemberTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "VLAN_MEMBER"}})
+    if err != nil {
+        log.Errorf("Failed to get VLAN_MEMBER: %v", err)
+        return nil, err
+    }
+
+    // Exclude LAG members from standalone ports
+    var ports []string
+    for port := range portTbl {
+        if !IsInterfaceInPortchannel(portChannelMemberTbl, port) {
+            ports = append(ports, port)
+        }
+    }
+    var portchannels []string
+    for pc := range portChannelTbl {
+        portchannels = append(portchannels, pc)
+    }
+    keys := append(ports, portchannels...)
+    keys = natsortInterfaces(keys)
+
+    // Optionally filter by interface
+    if intf != "" {
+        found := false
+        for _, k := range keys {
+            if k == intf {
+                found = true
+                keys = []string{intf}
+                break
+            }
+        }
+        if !found {
+            return nil, fmt.Errorf("Got unexpected extra argument %s", intf)
+        }
+    }
+
+    // Emit switchportStatus
+    switchportStatus := make([]map[string]string, 0, len(keys))
+    for _, k := range keys {
+        mode := GetInterfaceSwitchportMode(portTbl, portChannelTbl, vlanMemberTbl, k)
+
+        switchportStatus = append(switchportStatus, map[string]string{
+            "Interface": GetInterfaceNameForDisplay(k),
+            "Mode":      mode,
+        })
+    }
+
+    return json.Marshal(switchportStatus)
+}
+
+// IsInterfaceInPortchannel reports whether interfaceName is a member of any portchannel.
+func IsInterfaceInPortchannel(portchannelMemberTable map[string]interface{}, interfaceName string) bool {
+    if portchannelMemberTable == nil || interfaceName == "" {
+        return false
+    }
+    for k := range portchannelMemberTable {
+        _, member, ok := SplitCompositeKey(k)
+    if ok && member == interfaceName {
+            return true
+        }
+    }
+    return false
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -169,13 +169,6 @@ func init() {
 		showCmdOptionVerbose,
 	)
 	sdc.RegisterCliPath(
-		[]string{"SHOW", "ipv6", "interfaces"},
-		getIPv6Interfaces,
-		nil,
-		sdc.UnimplementedOption(showCmdOptionNamespace),
-		showCmdOptionDisplay,
-	)
-	sdc.RegisterCliPath(
 		[]string{"SHOW", "interface", "switchport", "config"},
 		getInterfaceSwitchportConfig,
 		nil,

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -168,4 +168,23 @@ func init() {
 		showCmdOptionCount,
 		showCmdOptionVerbose,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "ipv6", "interfaces"},
+		getIPv6Interfaces,
+		nil,
+		sdc.UnimplementedOption(showCmdOptionNamespace),
+		showCmdOptionDisplay,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "switchport", "config"},
+		getInterfaceSwitchportConfig,
+		nil,
+		showCmdOptionInterface,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "switchport", "status"},
+		getInterfaceSwitchportStatus,
+		nil,
+		showCmdOptionInterface,
+	)
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
 	log "github.com/golang/glog"
 
-	spb "github.com/sonic-net/sonic-gnmi/proto"
-	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 	"github.com/Workiva/go-datastructures/queue"
 	"github.com/go-redis/redis"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	spb "github.com/sonic-net/sonic-gnmi/proto"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 )
 
 const (
@@ -678,6 +679,12 @@ func populateDbtablePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]
 		}
 	}
 
+	if targetDbName == "CONFIG_DB" {
+		err = initAliasMap()
+		if err != nil {
+			return err
+		}
+	}
 
 	fullPath := path
 	if prefix != nil {

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -763,6 +763,14 @@ func AliasToPortNameMap() map[string]string {
 	return output
 }
 
+func PortToAliasNameMap() map[string]string {
+	output := make(map[string]string, len(name2aliasMap))
+	for portName, alias := range name2aliasMap {
+		output[portName] = alias
+	}
+	return output
+}
+
 // Populate real data paths from paths like
 // [COUNTERS_DB PERIODIC_WATERMARKS Ethernet* PriorityGroups] or
 // [COUNTERS_DB PERIODIC_WATERMARKS Ethernet64 PriorityGroups]

--- a/testdata/PORTS_SWITCHPORT.txt
+++ b/testdata/PORTS_SWITCHPORT.txt
@@ -1,0 +1,10 @@
+{
+  "PORT|Ethernet0": {"alias":"etp0"},
+  "PORT|Ethernet1": {"alias":"etp1"},
+  "PORT|Ethernet2": {"alias":"etp2"},
+  "PORT|Ethernet3": {"alias":"etp3"},
+  "PORT|Ethernet4": {"alias":"etp4"},
+  "PORT|Ethernet5": {"alias":"etp5"},
+  "PORT|Ethernet6": {"alias":"etp6"},
+  "PORT|Ethernet7": {"alias":"etp7"}
+}

--- a/testdata/VLAN_MEMBER_SWITCHPORT.txt
+++ b/testdata/VLAN_MEMBER_SWITCHPORT.txt
@@ -1,0 +1,8 @@
+{
+  "VLAN_MEMBER|Vlan1000|Ethernet0": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000|Ethernet1": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000|Ethernet2": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000|Ethernet3": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000|Ethernet4": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000|Ethernet5": {"tagging_mode":"untagged"}
+}

--- a/testdata/VLAN_MEMBER_SWITCHPORT.txt
+++ b/testdata/VLAN_MEMBER_SWITCHPORT.txt
@@ -4,5 +4,6 @@
   "VLAN_MEMBER|Vlan1000|Ethernet2": {"tagging_mode":"untagged"},
   "VLAN_MEMBER|Vlan1000|Ethernet3": {"tagging_mode":"untagged"},
   "VLAN_MEMBER|Vlan1000|Ethernet4": {"tagging_mode":"untagged"},
-  "VLAN_MEMBER|Vlan1000|Ethernet5": {"tagging_mode":"untagged"}
+  "VLAN_MEMBER|Vlan1000|Ethernet5": {"tagging_mode":"untagged"},
+  "VLAN_MEMBER|Vlan1000:Ethernet6": {"tagging_mode":"tagged"}
 }


### PR DESCRIPTION
# Why I did it
Provide gNMI GET endpoints for "interface/switchport/config" and "interface/switchport/status" so APIs expose the same information shown by the CLI show commands.

# How I did it
- Implemented GET handlers:
getInterfaceSwitchportConfig → returns per-interface rows: Interface, Mode, Untagged, Tagged
getInterfaceSwitchportStatus → returns per-interface rows: Interface, Mode
- Added helpers to mirror sonic-utilities behavior:
SplitCompositeKey (supports '|' and ':' for composite keys)
IsInterfaceInPortchannel (exclude LAG members from standalone ports)
GetInterfaceSwitchportMode (follows Python precedence: PORT.mode → PORTCHANNEL.mode → if member of VLAN_MEMBER then "trunk" else "routed")
GetInterfaceNameForDisplay (honors SONIC_CLI_IFACE_MODE=alias and preserves VLAN sub-interface suffix, e.g., Ethernet0.100 → etp0.100)

Data sources / Parity with sonic-utilities (explicit)

- Source DB: CONFIG_DB
   - Tables read:
      - PORT (per-port configuration, alias, optional "mode")
      - PORTCHANNEL (per-portchannel configuration, optional "mode")
      - PORTCHANNEL_MEMBER (LAG membership) — used to exclude LAG members from standalone port listing
      - VLAN_MEMBER (Vlan membership; uses tagging_mode to build untagged/tagged lists)
- No host commands are used for these handlers. All data is read from CONFIG_DB (same as sonic-utilities’ show implementation).

Output format (tree-like structure)
- Example (config): [ {"Interface":"Ethernet0","Mode":"trunk","Tagged":"","Untagged":"1000"}, {"Interface":"Ethernet1","Mode":"trunk","Tagged":"","Untagged":"1000"}, ... ]
- Example (status): [ {"Interface":"Ethernet0","Mode":"trunk"}, {"Interface":"Ethernet1","Mode":"trunk"}, ... ]

# How to verify it
1. Run UTs
2. Run the sonic-gnmi package on sonic device
```
:/# gnmi_get -xpath_target SHOW -xpath interface/switchport/config -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "switchport"
  >
  elem: <
    name: "config"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756223863250905572
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "switchport"
      >
      elem: <
        name: "config"
      >
    >
    val: <
      json_ietf_val: "[{\"Interface\":\"Ethernet0\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet1\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet2\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet3\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet4\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet5\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"},{\"Interface\":\"Ethernet6\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"},{\"Interface\":\"Ethernet7\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"},{\"Interface\":\"Ethernet16\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"},{\"Interface\":\"Ethernet17\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"}...............................,...{\"Interface\":\"Ethernet503\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"},{\"Interface\":\"Ethernet512\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"},{\"Interface\":\"Ethernet513\",\"Mode\":\"routed\",\"Tagged\":\"\",\"Untagged\":\"\"}]"
    >
  >
>


:/# gnmi_get -target_addr 127.0.0.1:50051 -insecure -logtostderr -xpath_target SHOW -encoding JSON_IETF -xpath 'interface/switchport/config[interface=Ethernet0]'
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "switchport"
  >
  elem: <
    name: "config"
    key: <
      key: "interface"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756227648990929535
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "switchport"
      >
      elem: <
        name: "config"
        key: <
          key: "interface"
          value: "Ethernet0"
        >
      >
    >
    val: <
      json_ietf_val: "[{\"Interface\":\"Ethernet0\",\"Mode\":\"trunk\",\"Tagged\":\"\",\"Untagged\":\"1000\"}]"
    >
  >
>
```

```
~$ show interface switchport config
Interface    Mode    Untagged    Tagged
-----------  ------  ----------  --------
Ethernet0    trunk   1000
Ethernet1    trunk   1000
Ethernet2    trunk   1000
Ethernet3    trunk   1000
Ethernet4    trunk   1000
Ethernet5    trunk   1000
Ethernet6    routed
Ethernet7    routed
Ethernet16   routed
Ethernet17   routed
Ethernet18   routed
Ethernet19   routed
Ethernet20   routed
......................
Ethernet501  routed
Ethernet502  routed
Ethernet503  routed
Ethernet512  routed
Ethernet513  routed

```

```
:/# gnmi_get -xpath_target SHOW -xpath interface/switchport/status -target_addr 127.0.0.1:50051 -logtost
derr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "switchport"
  >
  elem: <
    name: "status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756223924567443937
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "switchport"
      >
      elem: <
        name: "status"
      >
    >
    val: <
      json_ietf_val: "[{\"Interface\":\"Ethernet0\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet1\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet2\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet3\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet4\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet5\",\"Mode\":\"trunk\"},{\"Interface\":\"Ethernet6\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet7\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet16\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet17\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet18\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet19\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet20\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet21\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet22\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet23\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet32\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet33\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet34\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet35\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet36\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet37\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet38\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet39\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet48\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet49\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet50\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet51\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet52\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet53\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet54\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet55\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet64\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet65\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet66\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet67\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet68\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet69\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet70\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet71\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet80\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet81\",\"Mode\":\"routed\"},..........................{\"Interface\":\"Ethernet464\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet465\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet466\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet467\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet468\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet469\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet470\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet471\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet480\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet481\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet482\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet483\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet484\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet485\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet486\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet487\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet496\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet497\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet498\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet499\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet500\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet501\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet502\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet503\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet512\",\"Mode\":\"routed\"},{\"Interface\":\"Ethernet513\",\"Mode\":\"routed\"}]"
    >
  >
>

:/# gnmi_get -target_addr 127.0.0.1:50051 -insecure -logtostderr -xpath_target SHOW -encoding JSON_IETF -xpath 'interface/switchport/status[interface=Ethernet0]'
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "switchport"
  >
  elem: <
    name: "status"
    key: <
      key: "interface"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756227666321450398
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "switchport"
      >
      elem: <
        name: "status"
        key: <
          key: "interface"
          value: "Ethernet0"
        >
      >
    >
    val: <
      json_ietf_val: "[{\"Interface\":\"Ethernet0\",\"Mode\":\"trunk\"}]"
    >
  >
>
```

```
:~$ show interface switchport status
Interface    Mode
-----------  ------
Ethernet0    trunk
Ethernet1    trunk
Ethernet2    trunk
Ethernet3    trunk
Ethernet4    trunk
Ethernet5    trunk
Ethernet6    routed
Ethernet7    routed
Ethernet16   routed
Ethernet17   routed
..............................
Ethernet501  routed
Ethernet502  routed
Ethernet503  routed
Ethernet512  routed
Ethernet513  routed
```