### PR TITLE
Add support for `show srv6 stat`

### DIFF
--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -14,6 +14,7 @@ const (
 	showCmdOptionDomDesc           = "[dom=false] Also display Digital Optical Monitoring (DOM) data"
 	showCmdOptionPeriodDesc        = "[period=INTEGER] Display statistics over a specified period (in seconds)"
 	showCmdOptionJsonDesc          = "[json=true] No-op since response is in json format"
+	showCmdOptionSidDesc           = "[sid=TEXT] Filter by SRv6 SID"
 )
 
 var (
@@ -74,6 +75,12 @@ var (
 	showCmdOptionFetchFromHW = sdc.NewShowCmdOption(
 		"fetch-from-hardware",
 		showCmdOptionUnimplementedDesc,
+		sdc.StringValue,
+	)
+
+	showCmdOptionSid = sdc.NewShowCmdOption(
+		"sid",
+		showCmdOptionSidDesc,
 		sdc.StringValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -129,4 +129,10 @@ func init() {
 		nil,
 		showCmdOptionInterface,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "srv6", "stat"},
+		getSRv6Stat,
+		nil,
+		showCmdOptionSid,
+	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -130,7 +130,7 @@ func init() {
 		showCmdOptionInterface,
 	)
 	sdc.RegisterCliPath(
-		[]string{"SHOW", "srv6", "stat"},
+		[]string{"SHOW", "srv6", "stats"},
 		getSRv6Stat,
 		nil,
 		showCmdOptionSid,

--- a/show_client/srv6_cli.go
+++ b/show_client/srv6_cli.go
@@ -1,0 +1,59 @@
+package show_client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+func getSRv6Stat(options sdc.OptionMap) ([]byte, error) {
+	// Get SRv6 statistics per MY_SID entry
+	sid := ""
+	if option, ok := options["sid"].String(); ok {
+		sid = option
+	}
+
+	// First, query SID -> Counter OID mapping
+	queries := [][]string{
+		{"COUNTERS_DB", "COUNTERS_SRV6_NAME_MAP"},
+	}
+	sidCounterMap, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Unable to pull sid->counter_oid map for queries %v, got err %v", queries, err)
+		return nil, err
+	}
+
+	if sid != "" {
+		if _, ok := sidCounterMap[sid]; !ok {
+			log.Errorf("No such sid %s in COUNTERS_SRV6_NAME_MAP", sid)
+			return nil, fmt.Errorf("sid %s not found in COUNTERS_SRV6_NAME_MAP", sid)
+		}
+		sidCounterMap = map[string]interface{}{
+			sid: sidCounterMap[sid],
+		}
+	}
+
+	sidCounters := make([]map[string]string, 0, len(sidCounterMap))
+	for sid, counterOid := range sidCounterMap {
+		// Pull statistics for each sid and counterOid pair
+		log.V(2).Infof("Processing SID: %s with Counter OID: %v", sid, counterOid)
+		queries := [][]string{
+			{"COUNTERS_DB", "COUNTERS", counterOid},
+		}
+		sidStats, err := GetMapFromQueries(queries)
+		if err != nil {
+			log.Errorf("Unable to pull counters data for queries %v, got err %v", queries, err)
+			return nil, err
+		}
+
+		sidCounters = append(sidCounters, map[string]string{
+			"MySID":   sid,
+			"Packets": fmt.Sprintf("%v", sidStats["SAI_COUNTER_STAT_PACKETS"]),
+			"Bytes":   fmt.Sprintf("%v", sidStats["SAI_COUNTER_STAT_BYTES"]),
+		})
+	}
+
+	return json.Marshal(sidCounters)
+}

--- a/show_client/srv6_cli.go
+++ b/show_client/srv6_cli.go
@@ -36,7 +36,9 @@ func getSRv6Stat(options sdc.OptionMap) ([]byte, error) {
 	}
 
 	sidCounters := make([]map[string]string, 0, len(sidCounterMap))
-	for sid, counterOid := range sidCounterMap {
+	for k, v := range sidCounterMap {
+		sid := fmt.Sprint(k)
+		counterOid := fmt.Sprint(v)
 		// Pull statistics for each sid and counterOid pair
 		log.V(2).Infof("Processing SID: %s with Counter OID: %v", sid, counterOid)
 		queries := [][]string{


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support show srv6 stats in gnmi

#### How I did it
Implement a getter that gets counters data for SRv6 SIDs from COUNTERS_DB

#### (SHOW command specific) What sources are you using to fetch data?
COUNTERS_DB

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
Run on a device
Run UTs

#### (Show command specific) Output of show CLI that is equivalent to API output

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

<img width="2380" height="1482" alt="image" src="https://github.com/user-attachments/assets/6de44186-760a-4f70-baf7-c9feee8990fc" />


#### A picture of a cute animal (not mandatory but encouraged)
