### PR TITLE
Add show interface neighbor expected

### DIFF
--- a/gnmi_server/interface_neighbor_expected_cli_test.go
+++ b/gnmi_server/interface_neighbor_expected_cli_test.go
@@ -1,0 +1,149 @@
+package gnmi
+
+// Tests SHOW interface neighbor expected (JSON output)
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+)
+
+// getInterfaceNeighborExpected returns JSON like:
+// {
+//   "Ethernet2": {
+//     "neighbor":"DEVICE01T1",
+//     "neighbor_port":"Ethernet1",
+//     "neighbor_loopback":"10.1.1.1",
+//     "neighbor_mgmt":"192.0.2.10",
+//     "neighbor_type":"BackEndLeafRouter"
+//   }
+// }
+
+func TestShowInterfaceNeighborExpected(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	conn, err := grpc.Dial(TargetAddr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	neighborFile := "../testdata/DEVICE_NEIGHBOR_EXPECTED.txt"
+	neighborMetaFile := "../testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt"
+	neighborOnlyFile := "../testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt"
+
+	const (
+		expectedEmpty = `{}`
+
+		expectedSingle = `{"Ethernet2":{"neighbor":"DEVICE01T1","neighbor_port":"Ethernet1","neighbor_loopback":"10.1.1.1","neighbor_mgmt":"192.0.2.10","neighbor_type":"BackEndLeafRouter"}}`
+
+		expectedMissingMeta = `{"Ethernet4":{"neighbor":"DEVICE02T1","neighbor_port":"Ethernet9","neighbor_loopback":"None","neighbor_mgmt":"None","neighbor_type":"None"}}`
+	)
+
+	tests := []struct {
+		desc       string
+		textPbPath string
+		wantCode   codes.Code
+		wantResp   string
+		valTest    bool
+		testInit   func()
+		mockPatch  func() *gomonkey.Patches
+	}{
+		{
+			desc: "no data",
+			textPbPath: `
+              elem: <name: "interface">
+              elem: <name: "neighbor">
+              elem: <name: "expected">
+            `,
+			wantCode: codes.OK,
+			wantResp: expectedEmpty,
+			valTest:  true,
+			testInit: func() { FlushDataSet(t, ConfigDbNum) },
+		},
+		{
+			desc: "single neighbor (datasets)",
+			textPbPath: `
+              elem: <name: "interface">
+              elem: <name: "neighbor">
+              elem: <name: "expected">
+            `,
+			wantCode: codes.OK,
+			wantResp: expectedSingle,
+			valTest:  true,
+			testInit: func() {
+				FlushDataSet(t, ConfigDbNum)
+				AddDataSet(t, ConfigDbNum, neighborFile)
+				AddDataSet(t, ConfigDbNum, neighborMetaFile)
+			},
+		},
+		{
+			desc: "missing metadata defaults (datasets)",
+			textPbPath: `
+              elem: <name: "interface">
+              elem: <name: "neighbor">
+              elem: <name: "expected">
+            `,
+			wantCode: codes.OK,
+			wantResp: expectedMissingMeta,
+			valTest:  true,
+			testInit: func() {
+				FlushDataSet(t, ConfigDbNum)
+				AddDataSet(t, ConfigDbNum, neighborOnlyFile)
+			},
+		},
+		{
+			desc: "GetMapFromQueries error (neighbor)",
+			textPbPath: `
+              elem: <name: "interface">
+              elem: <name: "neighbor">
+              elem: <name: "expected">
+            `,
+			wantCode: codes.NotFound,
+			valTest:  false,
+			testInit: func() { FlushDataSet(t, ConfigDbNum) },
+			mockPatch: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(show_client.GetMapFromQueries,
+					func(q [][]string) (map[string]interface{}, error) {
+						return nil, fmt.Errorf("injected neighbor error")
+					})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.testInit != nil {
+				tc.testInit()
+			}
+			var patches *gomonkey.Patches
+			if tc.mockPatch != nil {
+				patches = tc.mockPatch()
+			}
+			if patches != nil {
+				defer patches.Reset()
+			}
+			wantVal := []byte(nil)
+			if tc.valTest {
+				wantVal = []byte(tc.wantResp)
+			}
+			runTestGet(t, ctx, gClient, "SHOW", tc.textPbPath, tc.wantCode, wantVal, tc.valTest)
+		})
+	}
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -282,4 +282,9 @@ func init() {
 		nil,
 		showCmdOptionInterface,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "neighbor", "expected"},
+		getInterfaceNeighborExpected,
+		nil,
+	)
 }

--- a/testdata/DEVICE_NEIGHBOR_EXPECTED.txt
+++ b/testdata/DEVICE_NEIGHBOR_EXPECTED.txt
@@ -1,0 +1,6 @@
+{
+  "DEVICE_NEIGHBOR|Ethernet2": {
+    "name": "DEVICE01T1",
+    "port": "Ethernet1"
+  }
+}

--- a/testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt
+++ b/testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt
@@ -1,0 +1,6 @@
+{
+  "DEVICE_NEIGHBOR|Ethernet4": {
+    "name": "DEVICE02T1",
+    "port": "Ethernet9"
+  }
+}

--- a/testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt
+++ b/testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt
@@ -1,0 +1,7 @@
+{
+  "DEVICE_NEIGHBOR_METADATA|DEVICE01T1": {
+    "lo_addr": "10.1.1.1",
+    "mgmt_addr": "192.0.2.10",
+    "type": "BackEndLeafRouter"
+  }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for "show interface neighbor expected"

#### How I did it

- Queried DEVICE_NEIGHBOR for interface → (device, port).

- Queried DEVICE_NEIGHBOR_METADATA for device → (lo_addr, mgmt_addr, type).

- Merged the two; if metadata missing, filled Loopback/Mgmt/Type with "None".

- Emitted per-interface JSON with keys: Neighbor, NeighborPort, NeighborLoopback, NeighborMgmt, NeighborType.

#### What sources are you using to fetch data?

- CONFIG_DB table DEVICE_NEIGHBOR: keyed by interface (e.g. DEVICE_NEIGHBOR|Ethernet2) providing fields name (device) and port (remote port).

- CONFIG_DB table DEVICE_NEIGHBOR_METADATA: keyed by device name (e.g. DEVICE_NEIGHBOR_METADATA|DEVICE01T1) providing lo_addr, mgmt_addr, type.

#### How to verify it

<img width="1447" height="386" alt="image" src="https://github.com/user-attachments/assets/cc53c51f-ba12-437d-9f0e-0813fab12144" />


#### Output of show CLI that is equivalent to API output
```
:~$ show interfaces neighbor expected 
LocalPort    Neighbor     NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  -----------  --------------  ------------------  --------------  ----------------
Ethernet0    ARISTA01T0   Ethernet1       None                172.16.175.32   BackEndToRRouter
Ethernet4    ARISTA02T0   Ethernet1       None                172.16.175.33   BackEndToRRouter
...
Ethernet40   ARISTA11T0   Ethernet1       None                172.16.175.42   BackEndToRRouter
```


#### Manual test output of API on device 

```text
root@sonic:/# gnmi_get -xpath_target SHOW -xpath interface/neighbor/expected -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "neighbor"
  >
  elem: <
    name: "expected"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756780424127551825
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "neighbor"
      >
      elem: <
        name: "expected"
      >
    >
    val: <
      json_ietf_val: "
{\"Ethernet0\":{\"Neighbor\":\"ARISTA01T0\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.175.32\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndToRRouter\"},
\"Ethernet4\":{\"Neighbor\":\"ARISTA02T0\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.175.33\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndToRRouter\"},
\"Ethernet40\":{\"Neighbor\":\"ARISTA11T0\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.175.42\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndToRRouter\"}}"
    >
  >
```