### PR TITLE
Add show system memory

### DIFF
--- a/gnmi_server/system_cli_test.go
+++ b/gnmi_server/system_cli_test.go
@@ -1,0 +1,91 @@
+package gnmi
+
+// Tests SHOW system-memory
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetSystemMemory(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	systemMemoryDefault := `[{"type":"Mem","total":"64252","used":"15017","free":"7526","shared":"563","buff/cache":"41708","available":"46228"},{"type":"Swap","total":"0","used":"0","free":"0"}]`
+
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc           string
+		pathTarget     string
+		textPbPath     string
+		wantRetCode    codes.Code
+		wantRespVal    interface{}
+		valTest        bool
+		mockOutputFile string
+		testInit       func()
+	}{
+		{
+			desc:       "query SHOW system-memory read error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "system-memory" >
+			`,
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:       "query SHOW system-memory",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "system-memory" >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespVal:    []byte(systemMemoryDefault),
+			valTest:        true,
+			mockOutputFile: "../testdata/SYSTEM_MEMORY.txt",
+			testInit: func() {
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		var patches *gomonkey.Patches
+		if test.mockOutputFile != "" {
+			patches = MockNSEnterOutput(t, test.mockOutputFile)
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+		if patches != nil {
+			patches.Reset()
+		}
+	}
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -207,4 +207,9 @@ func init() {
 		getDropcountersCapabilities,
 		nil,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "system-memory"},
+		getSystemMemory,
+		nil,
+	)
 }

--- a/show_client/system_cli.go
+++ b/show_client/system_cli.go
@@ -1,0 +1,35 @@
+package show_client
+
+import (
+	"encoding/json"
+	"strings"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+var showSystemMemoryCommand = "free -m"
+
+func getSystemMemory(options sdc.OptionMap) ([]byte, error) {
+	// Get data from host command
+	output, err := GetDataFromHostCommand(showSystemMemoryCommand)
+	if err != nil {
+		log.Errorf("Unable to succesfully execute command %v, get err %v", showSystemMemoryCommand, err)
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	header := strings.Fields(lines[0])
+	systemMemoryResponse := make([]map[string]string, len(lines)-1)
+	for i, line := range lines[1:] {
+		entry := make(map[string]string)
+		fields := strings.Fields(line)
+
+		entry["Type"] = fields[0]
+		for j, field := range fields[1:] {
+			entry[header[j]] = field
+		}
+		systemMemoryResponse[i] = entry
+	}
+	return json.Marshal(systemMemoryResponse), nil
+}

--- a/show_client/system_cli.go
+++ b/show_client/system_cli.go
@@ -25,7 +25,7 @@ func getSystemMemory(options sdc.OptionMap) ([]byte, error) {
 		entry := make(map[string]string)
 		fields := strings.Fields(line)
 
-		entry["Type"] = fields[0]
+		entry["type"] = strings.ReplaceAll(fields[0], ":", "")
 		for j, field := range fields[1:] {
 			entry[header[j]] = field
 		}

--- a/show_client/system_cli.go
+++ b/show_client/system_cli.go
@@ -31,5 +31,5 @@ func getSystemMemory(options sdc.OptionMap) ([]byte, error) {
 		}
 		systemMemoryResponse[i] = entry
 	}
-	return json.Marshal(systemMemoryResponse), nil
+	return json.Marshal(systemMemoryResponse)
 }

--- a/show_client/system_cli.go
+++ b/show_client/system_cli.go
@@ -20,16 +20,19 @@ func getSystemMemory(options sdc.OptionMap) ([]byte, error) {
 
 	lines := strings.Split(string(output), "\n")
 	header := strings.Fields(lines[0])
-	systemMemoryResponse := make([]map[string]string, len(lines)-1)
-	for i, line := range lines[1:] {
+	systemMemoryResponse := make([]map[string]string, 0)
+	for _, line := range lines[1:] {
 		entry := make(map[string]string)
 		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
 
 		entry["type"] = strings.ReplaceAll(fields[0], ":", "")
 		for j, field := range fields[1:] {
 			entry[header[j]] = field
 		}
-		systemMemoryResponse[i] = entry
+		systemMemoryResponse = append(systemMemoryResponse, entry)
 	}
 	return json.Marshal(systemMemoryResponse)
 }

--- a/testdata/SYSTEM_MEMORY.txt
+++ b/testdata/SYSTEM_MEMORY.txt
@@ -1,0 +1,3 @@
+               total        used        free      shared  buff/cache   available
+Mem:           64252       15017        7526         563       41708       46228
+Swap:              0           0           0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add support for "show system-memory" in sonic-gnmi

#### How I did it

Implement getSystemMemory that runs "free -m" to get the info.

#### (SHOW command specific) What sources are you using to fetch data?

Host command: "free -m"
Justification: there is no database source for this info.

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)

#### (Show command specific) Output of show CLI that is equivalent to API output

<img width="1402" height="196" alt="image" src="https://github.com/user-attachments/assets/73e9edb8-c787-4daa-bbe5-42cc2bb9c373" />


#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

```
root@str4-7060x6-64pe-11:/# gnmi_get -xpath_target SHOW -xpath system-memory -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "system-memory"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756680120234783783
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "system-memory"
      >
    >
    val: <
      json_ietf_val: "[{\"available\":\"25668\",\"buff/cache\":\"3152\",\"free\":\"23423\",\"shared\":\"441\",\"total\":\"31942\",\"type\":\"Mem\",\"used\":\"6273\"},{\"free\":\"0\",\"total\":\"0\",\"type\":\"Swap\",\"used\":\"0\"}]"
    >
  >
>

```

#### A picture of a cute animal (not mandatory but encouraged)
