### PR TITLE
Add SHOW implementation for processes

### DIFF
--- a/gnmi_server/processes_cli_test.go
+++ b/gnmi_server/processes_cli_test.go
@@ -1,0 +1,57 @@
+package gnmi
+
+// processes_cli_test.go
+// Tests SHOW processes (root help) and SHOW processes summary|cpu|mem
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestShowProcessesCommands(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Seed PROCESS_STATS sample data
+	FlushDataSet(t, StateDbNum)
+	AddDataSet(t, StateDbNum, "../testdata/PROCESS_STATS_SAMPLE.txt")
+
+	t.Run("SHOW processes (root help)", func(t *testing.T) {
+		textPbPath := `
+			elem: <name: "processes" >
+		`
+		expected := []byte(`{"subcommands":{"summary":"show/processes/summary","cpu":"show/processes/cpu","mem":"show/processes/mem"}}`)
+		runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+	})
+
+	t.Run("SHOW processes summary", func(t *testing.T) {
+		textPbPath := `
+			elem: <name: "processes" >
+			elem: <name: "summary" >
+		`
+		expected := []byte(`[{"PID":"123","PPID":"1","CMD":"redis-server","%MEM":"1.2","%CPU":"0.5","STIME":"10:54","TIME":"00:00:42","TT":"?","UID":"999"},{"PID":"456","PPID":"1","CMD":"swss","%MEM":"3.4","%CPU":"15.0","STIME":"10:55","TIME":"00:12:05","TT":"pts/0","UID":"0"},{"PID":"789","PPID":"456","CMD":"orchagent","%MEM":"2.0","%CPU":"7.5","STIME":"10:56","TIME":"00:03:10","TT":"pts/1","UID":"0"}]`)
+		runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, expected, true)
+	})
+}

--- a/show_client/processes_cli.go
+++ b/show_client/processes_cli.go
@@ -1,0 +1,117 @@
+package show_client
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+// processEntry represents a single process row from STATE_DB PROCESS_STATS
+type processEntry struct {
+	Pid  string `json:"PID"`
+	Ppid string `json:"PPID"`
+	Cmd  string `json:"CMD"`
+	Mem  string `json:"%MEM"`
+	Cpu  string `json:"%CPU"`
+	Stime string `json:"STIME,omitempty"`
+	Time  string `json:"TIME,omitempty"`
+	Tt    string `json:"TT,omitempty"`
+	Uid   string `json:"UID,omitempty"`
+}
+
+// Root help handler: SHOW processes
+func getProcessesRoot(options sdc.OptionMap) ([]byte, error) {
+	help := map[string]interface{}{
+		"subcommands": map[string]string{
+			"summary":	"show/processes/summary",
+			"cpu":      "show/processes/cpu",
+			"mem":      "show/processes/mem",
+		},
+	}
+	return json.Marshal(help)
+}
+
+func getProcessesSummary(options sdc.OptionMap) ([]byte, error) {
+	queries := [][]string{{"STATE_DB", "PROCESS_STATS"}}
+	processesSummary, err := GetMapFromQueries(queries)
+	if err != nil {
+		log.Errorf("Unable to query PROCESS_STATS from queries %v, got err: %v", queries, err)
+		return nil, err
+	}
+	if len(processesSummary) == 0 {
+		return []byte("[]"), nil
+	}
+	entries := buildProcessEntries(processesSummary)
+	if len(entries) == 0 {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(entries)
+}
+
+func buildProcessEntries(processesSummary map[string]interface{}) []processEntry {
+	entries := make([]processEntry, 0, len(processesSummary))
+	for key, raw := range processesSummary {
+		rec, _ := raw.(map[string]interface{})
+		if rec == nil {
+			continue
+		}
+
+		pid := key
+		if idx := lastIndexByte(key, '|'); idx >= 0 && idx+1 < len(key) {
+			pid = key[idx+1:]
+		}
+
+		// Skip non-numeric keys (e.g. metadata like LastUpdateTime) to ensure only real PIDs emitted
+		if _, err := strconv.Atoi(pid); err != nil {
+			continue
+		}
+
+		// Support records where actual fields are wrapped under a nested "value" map (as in provided sample).
+		if vRaw, ok := rec["value"]; ok {
+			if inner, ok2 := vRaw.(map[string]interface{}); ok2 && inner != nil {
+				rec = inner
+			}
+		}
+		// Helper accessor: return string value if present & non-empty, else default.
+		get := func(name, def string) string {
+			if v, ok := rec[name]; ok && v != nil {
+				s := fmt.Sprint(v)
+				if s != "" {
+					return s
+				}
+			}
+			return def
+		}
+
+		entries = append(entries, processEntry{
+			Pid:  pid,
+			Ppid: get("PPID", ""),
+			Cmd:  get("CMD", ""),
+			Mem:  get("%MEM", "0.0"),
+			Cpu:  get("%CPU", "0.0"),
+			Stime: get("STIME", ""),
+			Time:  get("TIME", ""),
+			Tt:    get("TT", ""),
+			Uid:   get("UID", ""),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		pi, _ := strconv.Atoi(entries[i].Pid)
+		pj, _ := strconv.Atoi(entries[j].Pid)
+		return pi < pj
+	})
+	return entries
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -193,4 +193,20 @@ func init() {
 		nil,
 		showCmdOptionInterface,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "processes"},
+		getProcessesRoot,
+		map[string]string{
+			"summary": "show/processes/summary",
+			"cpu":     "show/processes/cpu",
+			"mem":     "show/processes/mem",
+		},
+		showCmdOptionVerbose,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "processes", "summary"},
+		getProcessesSummary,
+		nil,
+		showCmdOptionVerbose,
+	)
 }

--- a/testdata/PROCESS_STATS_SAMPLE.txt
+++ b/testdata/PROCESS_STATS_SAMPLE.txt
@@ -1,0 +1,32 @@
+{
+    "PROCESS_STATS|123": {
+        "%CPU": "0.5",
+        "%MEM": "1.2",
+        "CMD": "redis-server",
+        "PPID": "1",
+        "STIME": "10:54",
+        "TIME": "00:00:42",
+        "TT": "?",
+        "UID": "999"
+    },
+    "PROCESS_STATS|456": {
+        "%CPU": "15.0",
+        "%MEM": "3.4",
+        "CMD": "swss",
+        "PPID": "1",
+        "STIME": "10:55",
+        "TIME": "00:12:05",
+        "TT": "pts/0",
+        "UID": "0"
+    },
+    "PROCESS_STATS|789": {
+        "%CPU": "7.5",
+        "%MEM": "2.0",
+        "CMD": "orchagent",
+        "PPID": "456",
+        "STIME": "10:56",
+        "TIME": "00:03:10",
+        "TT": "pts/1",
+        "UID": "0"
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

# Why I did it
---
Add support for SHOW processes.
Add support for SHOW processes summary.

# How I did it
---
SHOW processes is a helper function, it will return the support command.
For `show processes summary`, it gets data from PROCESS_STATS in STATE_DB.
For example, Key is PROCESS_STATS |1, value is "{'CMD': '', '%CPU': '0.0', '%MEM': '0.0', 'PPID': '2', 'STIME': 'Sep01', 'TIME': '0:00:00', 'TT': 'None', 'UID': '0'}".



# How to verify it
---
UT and manually run

#### Run 'show processes summary' command on host
```sh
admin@str5-sn5640-4:~$ show processes summary
    PID    PPID CMD                         %MEM %CPU
      1       0 /sbin/init                   0.0  0.1
      2       0 [kthreadd]                   0.0  0.0
      3       2 [rcu_gp]                     0.0  0.0
      4       2 [rcu_par_gp]                 0.0  0.0
      5       2 [slub_flushwq]               0.0  0.0
      6       2 [netns]                      0.0  0.0
      8       2 [kworker/0:0H-events_highpr  0.0  0.0
     10       2 [mm_percpu_wq]               0.0  0.0
     11       2 [rcu_tasks_kthread]          0.0  0.0
     12       2 [rcu_tasks_rude_kthread]     0.0  0.0
     13       2 [rcu_tasks_trace_kthread]    0.0  0.0
```
#### Run "show processes/summary" command with gnmi client
```sh
root@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/cpu -target_addr 127.0.0.1:50051 -logtostderr -insecure truroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/cp -target_addr 127.0.0.1:50051 -logtostderr -insecure trueroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/cps -target_addr 127.0.0.1:50051 -logtostderr -insecure truroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/cp -target_addr 127.0.0.1:50051 -logtostderr -insecure trueroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/c -target_addr 127.0.0.1:50051 -logtostderr -insecure trueroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/su -target_addr 127.0.0.1:50051 -logtostderr -insecure trueroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/sum -target_addr 127.0.0.1:50051 -logtostderr -insecure truroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/summ -target_addr 127.0.0.1:50051 -logtostderr -insecure trroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/summa -target_addr 127.0.0.1:50051 -logtostderr -insecure troot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/summar -target_addr 127.0.0.1:50051 -logtostderr -insecure root@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/summary -target_addr 127.0.0.1:50051 -logtostderr -insecureroot@str5-sn5640-4:/# gnmi_get -xpath_target SHOW -xpath processes/summary -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "processes"
  >
  elem: <
    name: "summary"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756702779937483800
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "processes"
      >
      elem: <
        name: "summary"
      >
    >
    val: <
      json_ietf_val: "[{"PID":"1","PPID":"0","CMD":"/sbin/init","%MEM":"0.1","%CPU":"0.0","STIME":"Aug26","TIME":"0:10:21","TT":"None","UID":"0"},{"PID":"2","PPID":"0","CMD":"","%MEM":"0.0","%CPU":"0.0","STIME":"Aug26","TIME":"0:00:00","TT":"None","UID":"0"},{"PID":"3","PPID":"2","CMD":"","%MEM":"0.0","%CPU":"0.0","STIME":"Aug26","TIME":"0:00:00","TT":"None","UID":"0"}]"
    >
  >
```

Json data:
```json
[
    {
        "CMD": "sx_sdk --logger libsai.so",
        "%CPU": "0.0",
        "%MEM": "2.9",
        "PID": "2441817",
        "PPID": "2441169",
        "STIME": "Aug29",
        "TIME": "5:00:21",
        "TT": "None",
        "UID": "0"
    },
    {
        "CMD": "/usr/bin/syncd -u -s -B null -l -p /tmp/sai.profile",
        "%CPU": "0.0",
        "%MEM": "0.9",
        "PID": "2441777",
        "PPID": "2441169",
        "STIME": "Aug29",
        "TIME": "2:38:06",
        "TT": "None",
        "UID": "0"
    },
    {
        "CMD": "/usr/bin/dockerd -H unix:// --storage-driver=overlay2 --bip=240.127.1.1/24 --iptables=false --ipv6=true --fixed-cidr-v6=fd00::/80",
        "%CPU": "0.0",
        "%MEM": "0.4",
        "PID": "2424577",
        "PPID": "1",
        "STIME": "Aug29",
        "TIME": "0:23:30",
        "TT": "None",
        "UID": "0"
    }
]
```

for Show Processes, gnmi response:
```json
{
    "subcommands": {
        "cpu": "show/processes/cpu",
        "mem": "show/processes/mem",
        "summary": "show/processes/summary"
    }
}
```


# Code Coverage
<img width="643" height="261" alt="image" src="https://github.com/user-attachments/assets/00273ae5-75d0-47e1-8d12-63b92c2e9438" />

