### PR TITLE
Feature/show ipv6 route

### DIFF
--- a/gnmi_server/ipv6_route_cli_test.go
+++ b/gnmi_server/ipv6_route_cli_test.go
@@ -1,0 +1,145 @@
+package gnmi
+
+// ipv6_route_cli_test.go
+// Tests SHOW ipv6 route (pass-through JSON) with args option
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"github.com/agiledragon/gomonkey/v2"
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetIPv6Route(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// Expected JSON strings loaded from files via MockNSEnterOutput*; we still compare raw bytes.
+	tests := []struct {
+		desc           string
+		pathTarget     string
+		textPbPath     string
+		wantRetCode    codes.Code
+		wantRespFile   string // expected body (same as mock output)
+		mockOutputFile string // file to feed to nsenter mock
+		multiAsic      bool
+		valTest        bool
+	}{
+		{
+			desc:       "query SHOW ipv6 route base",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE.json",
+			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE.json",
+			valTest:        true,
+		},
+		{
+			desc:       "query SHOW ipv6 route bgp",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" key <key: "args" value: "bgp" > >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
+			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
+			valTest:        true,
+		},
+		{
+			desc:       "query SHOW ipv6 route prefix arg",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" key <key: "args" value: "2001:db8::/64" > >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_PREFIX.json",
+			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE_PREFIX.json",
+			valTest:        true,
+		},
+		{
+			desc:       "query SHOW ipv6 route args include json (no duplicate)",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" key <key: "args" value: "bgp json" > >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
+			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
+			valTest:        true,
+		},
+		{
+			desc:       "query SHOW ipv6 route invalid JSON output",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" >
+			`,
+			wantRetCode:    codes.NotFound,
+			mockOutputFile: "../testdata/INVALID_JSON.txt",
+			valTest:        false,
+		},
+		{
+			desc:       "query SHOW ipv6 route multi-asic unsupported",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" >
+			`,
+			wantRetCode: codes.NotFound,
+			multiAsic:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var allPatches []*gomonkey.Patches
+			// Patch multi-asic behavior
+			allPatches = append(allPatches, gomonkey.ApplyFunc(show_client.IsMultiAsic, func() bool { return test.multiAsic }))
+			if test.mockOutputFile != "" {
+				allPatches = append(allPatches, MockNSEnterOutput(t, test.mockOutputFile))
+			}
+			// Load expected file if needed
+			expected := []byte{}
+			if test.wantRespFile != "" {
+				b, err := os.ReadFile(test.wantRespFile)
+				if err != nil {
+					t.Fatalf("read expected file: %v", err)
+				}
+				expected = b
+			}
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, expected, test.valTest)
+			for _, p := range allPatches {
+				p.Reset()
+			}
+		})
+	}
+}

--- a/show_client/ipv6_route_cli.go
+++ b/show_client/ipv6_route_cli.go
@@ -1,0 +1,58 @@
+package show_client
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+// getIPv6Route is the getter function for the "show ipv6 route" command.
+// This command is only supported on single-ASIC devices. It directly
+// returns the JSON output from vtysh.
+func getIPv6Route(options sdc.OptionMap) ([]byte, error) {
+	if IsMultiAsic() {
+		log.Errorf("Attempted to execute 'show ipv6 route' on a multi-ASIC platform")
+		return nil, fmt.Errorf("'show ipv6 route' is not supported on multi-ASIC platforms")
+	}
+
+	cmdArgs := []string{"show", "ipv6", "route"}
+	jsonArgPresent := false
+
+	if val, ok := options["args"]; ok {
+		if frrArgs, ok := val.String(); ok {
+			userArgs := strings.Fields(frrArgs)
+			for _, arg := range userArgs {
+				if arg == "json" {
+					jsonArgPresent = true
+				}
+				cmdArgs = append(cmdArgs, arg)
+			}
+		}
+	}
+
+	if !jsonArgPresent {
+		cmdArgs = append(cmdArgs, "json")
+	}
+
+	vtyshCmdArgs := strings.Join(cmdArgs, " ")
+
+	// For single-ASIC, run in the default BGP instance on the host.
+	vtyshIPv6RouteCmd := fmt.Sprintf("vtysh -c \"%s\"", vtyshCmdArgs)
+
+	output, err := GetDataFromHostCommand(vtyshIPv6RouteCmd)
+	if err != nil {
+		log.Errorf("Unable to successfully execute command %v, get err %v", vtyshIPv6RouteCmd, err)
+		return nil, err
+	}
+
+	// Validate & compact JSON: unmarshal then directly marshal
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		log.Errorf("Invalid JSON from vtysh command '%s': %v", vtyshIPv6RouteCmd, err)
+		return nil, err
+	}
+	return json.Marshal(parsed)
+}

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -26,6 +26,7 @@ const (
 	showCmdOptionIPAddressDesc     = "[ipaddress=TEXT] Filter by single IP address"
 	showCmdOptionIPV6AddressDesc   = "[ipaddress=TEXT] Filter by IPv6 address"
 	showCmdOptionInfoTypeDesc      = "[info_type=TEXT] Filter by information type"
+	showCmdOptionFrrRouteArgsDesc  = "[args=TEXT] Filter by FRR route arguments"
 )
 
 var (
@@ -169,6 +170,12 @@ var (
 	showCmdOptionInfoTypeForBgpNetwork = sdc.NewShowCmdOption(
 		"info_type",
 		showCmdOptionInfoTypeDesc,
+		sdc.StringValue,
+	)
+
+	showCmdOptionFrrRouteArgs = sdc.NewShowCmdOption(
+		"args",
+		showCmdOptionFrrRouteArgsDesc,
 		sdc.StringValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -133,6 +133,14 @@ func init() {
 		showCmdOptionDisplay,
 	)
 	sdc.RegisterCliPath(
+		[]string{"SHOW", "ipv6", "route"},
+		getIPv6Route,
+		nil,
+		sdc.UnimplementedOption(showCmdOptionNamespace),
+		showCmdOptionDisplay,
+		showCmdOptionFrrRouteArgs,
+	)
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "lldp", "table"},
 		getLLDPTable,
 		nil,

--- a/testdata/VTYSH_SHOW_IPV6_ROUTE.json
+++ b/testdata/VTYSH_SHOW_IPV6_ROUTE.json
@@ -1,0 +1,22 @@
+{
+  "2001:db8:1::/64": [
+    {
+      "prefix": "2001:db8:1::/64",
+      "protocol": "bgp",
+      "distance": 20,
+      "metric": 0,
+      "uptime": "00:00:10",
+      "selected": true,
+      "internalNextHopNum": 1,
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "ip": "fe80::2e0:ecff:fe3b:c8c6",
+          "interfaceName": "Ethernet0",
+          "active": true,
+          "onLink": true
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json
+++ b/testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json
@@ -1,0 +1,22 @@
+{
+  "2001:db8:2::/64": [
+    {
+      "prefix": "2001:db8:2::/64",
+      "protocol": "bgp",
+      "distance": 20,
+      "metric": 0,
+      "uptime": "00:00:20",
+      "selected": true,
+      "internalNextHopNum": 1,
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "ip": "fe80::2e0:ecff:fe3b:c8d0",
+          "interfaceName": "Ethernet4",
+          "active": true,
+          "onLink": true
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/VTYSH_SHOW_IPV6_ROUTE_PREFIX.json
+++ b/testdata/VTYSH_SHOW_IPV6_ROUTE_PREFIX.json
@@ -1,0 +1,21 @@
+{
+  "2001:db8::/64": [
+    {
+      "prefix": "2001:db8::/64",
+      "protocol": "static",
+      "distance": 1,
+      "metric": 0,
+      "uptime": "00:01:00",
+      "selected": true,
+      "internalNextHopNum": 1,
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "ip": "2001:db8:dead:beef::1",
+          "interfaceName": "Null0",
+          "active": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add gNMI getter for `show ipv6 route` (single-ASIC only) so clients can fetch FRR IPv6 route data via gNMI in JSON.

#### How I did it
* Added getIPv6Route getter.
* Builds vtysh -c "show ipv6 route [args] json". Appends json if missing.
* Executes via GetDataFromHostCommand (nsenter).
* Rejects multi-ASIC with codes.Unimplemented.
* Normalizes output (unmarshal/remarshal) and returns compact JSON.

#### (SHOW command specific) What sources are you using to fetch data?
Only FRR via vtysh `show ipv6 route … json`; no Redis/DB access.

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
<img width="1410" height="830" alt="image" src="https://github.com/user-attachments/assets/98f27eb1-de79-44a1-916c-c7ab2b5b2765" />

#### (Show command specific) Output of show CLI that is equivalent to API output
```shell
admin@str5-7060x6-moby-512-4:~$ show ipv6 route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

C>*2a01:111:e210:b000::/64 is directly connected, eth0, 6d07h24m
S>*fc00:1::/64 [1/0] is directly connected, Loopback0, 6d07h23m
C>*fc00:1::32/128 is directly connected, Loopback0, 6d07h23m
K *fc00:1::32/128 [0/256] is directly connected, Loopback0, 6d07h23m
C *fe80::/64 is directly connected, Ethernet464, 6d07h23m
C *fe80::/64 is directly connected, Ethernet452, 6d07h23m
C *fe80::/64 is directly connected, Ethernet496, 6d07h23m
C *fe80::/64 is directly connected, Ethernet500, 6d07h23m
C *fe80::/64 is directly connected, Ethernet492, 6d07h23m
C *fe80::/64 is directly connected, Ethernet504, 6d07h23m
C *fe80::/64 is directly connected, Ethernet508, 6d07h23m
C *fe80::/64 is directly connected, Ethernet424, 6d07h23m
C *fe80::/64 is directly connected, Ethernet460, 6d07h23m
C *fe80::/64 is directly connected, Ethernet448, 6d07h23m
C *fe80::/64 is directly connected, Ethernet436, 6d07h23m
C *fe80::/64 is directly connected, Ethernet468, 6d07h23m
C *fe80::/64 is directly connected, Ethernet484, 6d07h23m
C *fe80::/64 is directly connected, Ethernet480, 6d07h23m
C *fe80::/64 is directly connected, Ethernet476, 6d07h23m
C *fe80::/64 is directly connected, Ethernet488, 6d07h23m
C *fe80::/64 is directly connected, Ethernet412, 6d07h23m
C *fe80::/64 is directly connected, Ethernet356, 6d07h23m
C *fe80::/64 is directly connected, Ethernet344, 6d07h23m
C *fe80::/64 is directly connected, Ethernet440, 6d07h23m
C *fe80::/64 is directly connected, Ethernet420, 6d07h23m
C *fe80::/64 is directly connected, Ethernet456, 6d07h23m
C *fe80::/64 is directly connected, Ethernet472, 6d07h23m
C *fe80::/64 is directly connected, Ethernet400, 6d07h23m
C *fe80::/64 is directly connected, Ethernet392, 6d07h23m
C *fe80::/64 is directly connected, Ethernet408, 6d07h23m
C *fe80::/64 is directly connected, Ethernet352, 6d07h23m
C *fe80::/64 is directly connected, Ethernet336, 6d07h23m
C *fe80::/64 is directly connected, Ethernet348, 6d07h23m
C *fe80::/64 is directly connected, Ethernet332, 6d07h23m
C *fe80::/64 is directly connected, Ethernet428, 6d07h23m
C *fe80::/64 is directly connected, Ethernet444, 6d07h23m
C *fe80::/64 is directly connected, Ethernet432, 6d07h23m
C *fe80::/64 is directly connected, Ethernet388, 6d07h23m
C *fe80::/64 is directly connected, Ethernet384, 6d07h23m
C *fe80::/64 is directly connected, Ethernet404, 6d07h23m
C *fe80::/64 is directly connected, Ethernet396, 6d07h23m
C *fe80::/64 is directly connected, Ethernet340, 6d07h23m
C *fe80::/64 is directly connected, Ethernet320, 6d07h23m
C *fe80::/64 is directly connected, Ethernet360, 6d07h23m
C *fe80::/64 is directly connected, Ethernet364, 6d07h23m
C *fe80::/64 is directly connected, Ethernet416, 6d07h23m
C *fe80::/64 is directly connected, Ethernet368, 6d07h23m
C *fe80::/64 is directly connected, Ethernet372, 6d07h23m
C *fe80::/64 is directly connected, Ethernet376, 6d07h23m
C *fe80::/64 is directly connected, Ethernet380, 6d07h23m
C *fe80::/64 is directly connected, Ethernet324, 6d07h23m
C *fe80::/64 is directly connected, Ethernet308, 6d07h23m
C *fe80::/64 is directly connected, Ethernet280, 6d07h23m
C *fe80::/64 is directly connected, Ethernet200, 6d07h23m
C *fe80::/64 is directly connected, Ethernet236, 6d07h23m
C *fe80::/64 is directly connected, Ethernet328, 6d07h23m
C *fe80::/64 is directly connected, Ethernet272, 6d07h23m
C *fe80::/64 is directly connected, Ethernet276, 6d07h23m
C *fe80::/64 is directly connected, Ethernet292, 6d07h23m
C *fe80::/64 is directly connected, Ethernet304, 6d07h23m
C *fe80::/64 is directly connected, Ethernet288, 6d07h23m
C *fe80::/64 is directly connected, Ethernet296, 6d07h23m
C *fe80::/64 is directly connected, Ethernet316, 6d07h23m
C *fe80::/64 is directly connected, Ethernet264, 6d07h23m
C *fe80::/64 is directly connected, Ethernet252, 6d07h23m
C *fe80::/64 is directly connected, Ethernet300, 6d07h23m
C *fe80::/64 is directly connected, Ethernet312, 6d07h23m
C *fe80::/64 is directly connected, Ethernet220, 6d07h23m
C *fe80::/64 is directly connected, Ethernet268, 6d07h23m
C *fe80::/64 is directly connected, Ethernet248, 6d07h23m
C *fe80::/64 is directly connected, Ethernet232, 6d07h23m
C *fe80::/64 is directly connected, Ethernet284, 6d07h23m
C *fe80::/64 is directly connected, Ethernet188, 6d07h23m
C *fe80::/64 is directly connected, Ethernet204, 6d07h23m
C *fe80::/64 is directly connected, Ethernet256, 6d07h23m
C *fe80::/64 is directly connected, Ethernet260, 6d07h23m
C *fe80::/64 is directly connected, Ethernet240, 6d07h23m
C *fe80::/64 is directly connected, Ethernet216, 6d07h23m
C *fe80::/64 is directly connected, Ethernet224, 6d07h23m
C *fe80::/64 is directly connected, Ethernet228, 6d07h23m
C *fe80::/64 is directly connected, Ethernet164, 6d07h23m
C *fe80::/64 is directly connected, Ethernet244, 6d07h23m
C *fe80::/64 is directly connected, Ethernet212, 6d07h23m
C *fe80::/64 is directly connected, Ethernet176, 6d07h23m
C *fe80::/64 is directly connected, Ethernet196, 6d07h23m
C *fe80::/64 is directly connected, Ethernet208, 6d07h23m
C *fe80::/64 is directly connected, Ethernet192, 6d07h23m
C *fe80::/64 is directly connected, Ethernet180, 6d07h23m
C *fe80::/64 is directly connected, Ethernet152, 6d07h23m
C *fe80::/64 is directly connected, Ethernet168, 6d07h23m
C *fe80::/64 is directly connected, Ethernet184, 6d07h23m
C *fe80::/64 is directly connected, Ethernet160, 6d07h23m
C *fe80::/64 is directly connected, Ethernet156, 6d07h23m
C *fe80::/64 is directly connected, Ethernet140, 6d07h23m
C *fe80::/64 is directly connected, Ethernet144, 6d07h23m
C *fe80::/64 is directly connected, Ethernet136, 6d07h23m
C *fe80::/64 is directly connected, Ethernet148, 6d07h23m
C *fe80::/64 is directly connected, Ethernet172, 6d07h23m
C *fe80::/64 is directly connected, Ethernet132, 6d07h23m
C *fe80::/64 is directly connected, Ethernet128, 6d07h23m
C *fe80::/64 is directly connected, bcm0_0, 6d07h23m
C *fe80::/64 is directly connected, bcm0, 6d07h23m
C *fe80::/64 is directly connected, Bridge, 6d07h23m
C *fe80::/64 is directly connected, dummy, 6d07h23m
C *fe80::/64 is directly connected, Loopback0, 6d07h23m
C>*fe80::/64 is directly connected, eth0, 6d07h24m
```
#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```shell
root@str5-7060x6-moby-512-4:/# gnmi_get -xpath_target SHOW -xpath ipv6/route -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "ipv6"
  >
  elem: <
    name: "route"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756786763590426891
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "ipv6"
      >
      elem: <
        name: "route"
      >
    >
    val: <
      json_ietf_val: "{\"2a01:111:e210:b000::/64\":[{\"destSelected\":true,\"distance\":0,\"installed\":true,\"installedNexthopGroupId\":7,\"internalFlags\":264,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":7,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":2,\"interfaceName\":\"eth0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"2a01:111:e210:b000::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"selected\":true,\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"}],\"fc00:1::/64\":[{\"destSelected\":true,\"distance\":1,\"installed\":true,\"installedNexthopGroupId\":11,\"internalFlags\":329,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fc00:1::/64\",\"prefixLen\":64,\"protocol\":\"static\",\"selected\":true,\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"}],\"fc00:1::32/128\":[{\"destSelected\":true,\"distance\":0,\"installed\":true,\"installedNexthopGroupId\":11,\"internalFlags\":264,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fc00:1::32/128\",\"prefixLen\":128,\"protocol\":\"connected\",\"selected\":true,\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":0,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":256,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"prefix\":\"fc00:1::32/128\",\"prefixLen\":128,\"protocol\":\"kernel\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"}],\"fe80::/64\":[{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":218,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":106,\"interfaceName\":\"Ethernet464\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":215,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":111,\"interfaceName\":\"Ethernet452\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":216,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":101,\"interfaceName\":\"Ethernet496\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":211,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":99,\"interfaceName\":\"Ethernet500\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":212,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":95,\"interfaceName\":\"Ethernet492\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":207,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":94,\"interfaceName\":\"Ethernet504\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":208,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":93,\"interfaceName\":\"Ethernet508\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":203,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":122,\"interfaceName\":\"Ethernet424\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":204,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":113,\"interfaceName\":\"Ethernet460\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":199,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":112,\"interfaceName\":\"Ethernet448\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":200,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":109,\"interfaceName\":\"Ethernet436\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":195,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":105,\"interfaceName\":\"Ethernet468\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":196,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":102,\"interfaceName\":\"Ethernet484\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":191,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":100,\"interfaceName\":\"Ethernet480\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":192,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":98,\"interfaceName\":\"Ethernet476\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":187,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":97,\"interfaceName\":\"Ethernet488\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":188,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":75,\"interfaceName\":\"Ethernet412\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":183,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":137,\"interfaceName\":\"Ethernet356\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":184,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":128,\"interfaceName\":\"Ethernet344\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":179,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":118,\"interfaceName\":\"Ethernet440\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":180,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":115,\"interfaceName\":\"Ethernet420\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":175,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":114,\"interfaceName\":\"Ethernet456\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":176,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":96,\"interfaceName\":\"Ethernet472\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":171,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":85,\"interfaceName\":\"Ethernet400\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":172,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":79,\"interfaceName\":\"Ethernet392\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":168,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":76,\"interfaceName\":\"Ethernet408\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":165,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":138,\"interfaceName\":\"Ethernet352\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":166,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":134,\"interfaceName\":\"Ethernet336\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":161,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":127,\"interfaceName\":\"Ethernet348\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":162,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":125,\"interfaceName\":\"Ethernet332\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":157,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":121,\"interfaceName\":\"Ethernet428\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":158,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":117,\"interfaceName\":\"Ethernet444\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":153,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":110,\"interfaceName\":\"Ethernet432\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":154,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":86,\"interfaceName\":\"Ethernet388\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":149,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":84,\"interfaceName\":\"Ethernet384\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":150,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":83,\"interfaceName\":\"Ethernet404\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":145,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":81,\"interfaceName\":\"Ethernet396\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":146,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":133,\"interfaceName\":\"Ethernet340\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":141,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":132,\"interfaceName\":\"Ethernet320\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":142,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":130,\"interfaceName\":\"Ethernet360\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":137,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":129,\"interfaceName\":\"Ethernet364\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":138,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":116,\"interfaceName\":\"Ethernet416\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":133,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":90,\"interfaceName\":\"Ethernet368\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":134,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":89,\"interfaceName\":\"Ethernet372\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":129,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":82,\"interfaceName\":\"Ethernet376\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":130,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":80,\"interfaceName\":\"Ethernet380\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":125,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":131,\"interfaceName\":\"Ethernet324\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":126,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":67,\"interfaceName\":\"Ethernet308\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":121,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":64,\"interfaceName\":\"Ethernet280\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":122,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":49,\"interfaceName\":\"Ethernet200\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":117,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":11,\"interfaceName\":\"Ethernet236\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":118,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":126,\"interfaceName\":\"Ethernet328\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":113,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":74,\"interfaceName\":\"Ethernet272\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":114,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":73,\"interfaceName\":\"Ethernet276\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":109,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":70,\"interfaceName\":\"Ethernet292\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":110,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":69,\"interfaceName\":\"Ethernet304\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":105,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":68,\"interfaceName\":\"Ethernet288\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":106,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":65,\"interfaceName\":\"Ethernet296\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":100,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":61,\"interfaceName\":\"Ethernet316\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":101,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":18,\"interfaceName\":\"Ethernet264\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":102,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":15,\"interfaceName\":\"Ethernet252\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":95,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":63,\"interfaceName\":\"Ethernet300\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":96,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":62,\"interfaceName\":\"Ethernet312\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":92,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":45,\"interfaceName\":\"Ethernet220\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":89,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":17,\"interfaceName\":\"Ethernet268\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":90,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":16,\"interfaceName\":\"Ethernet248\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":85,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":12,\"interfaceName\":\"Ethernet232\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":86,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":66,\"interfaceName\":\"Ethernet284\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":81,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":50,\"interfaceName\":\"Ethernet188\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":82,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":47,\"interfaceName\":\"Ethernet204\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":77,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":26,\"interfaceName\":\"Ethernet256\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":78,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":25,\"interfaceName\":\"Ethernet260\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":73,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":22,\"interfaceName\":\"Ethernet240\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":74,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":46,\"interfaceName\":\"Ethernet216\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":69,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":20,\"interfaceName\":\"Ethernet224\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":70,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":19,\"interfaceName\":\"Ethernet228\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":65,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":31,\"interfaceName\":\"Ethernet164\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":66,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":21,\"interfaceName\":\"Ethernet244\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":61,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":51,\"interfaceName\":\"Ethernet212\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":62,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":58,\"interfaceName\":\"Ethernet176\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":57,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":54,\"interfaceName\":\"Ethernet196\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":58,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":53,\"interfaceName\":\"Ethernet208\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":53,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":52,\"interfaceName\":\"Ethernet192\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":54,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":57,\"interfaceName\":\"Ethernet180\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":49,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":38,\"interfaceName\":\"Ethernet152\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":50,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":34,\"interfaceName\":\"Ethernet168\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":45,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":48,\"interfaceName\":\"Ethernet184\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":46,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":32,\"interfaceName\":\"Ethernet160\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":41,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":37,\"interfaceName\":\"Ethernet156\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":42,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":41,\"interfaceName\":\"Ethernet140\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":37,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":30,\"interfaceName\":\"Ethernet144\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":38,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":42,\"interfaceName\":\"Ethernet136\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":33,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":29,\"interfaceName\":\"Ethernet148\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":34,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":33,\"interfaceName\":\"Ethernet172\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":29,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":35,\"interfaceName\":\"Ethernet132\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":30,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":36,\"interfaceName\":\"Ethernet128\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":26,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":10,\"interfaceName\":\"bcm0_0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":24,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":9,\"interfaceName\":\"bcm0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":16,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":4,\"interfaceName\":\"Bridge\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":17,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":6,\"interfaceName\":\"dummy\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":256,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"},{\"destSelected\":true,\"distance\":0,\"installed\":true,\"installedNexthopGroupId\":7,\"internalFlags\":264,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":7,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":2,\"interfaceName\":\"eth0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fe80::/64\",\"prefixLen\":64,\"protocol\":\"connected\",\"selected\":true,\"table\":254,\"uptime\":\"6d06h20m\",\"vrfId\":0,\"vrfName\":\"default\"}]}"
    >
  >
>
```
#### A picture of a cute animal (not mandatory but encouraged)
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⠤⠤⠴⠒⠒⠒⠶⠶⠶⠤⠤⠴⠶⠶⠤⠤⠤⠤⠤⠤⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⠟⠉⢀⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣈⠱⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⠟⢁⣠⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⣷⡈⠛⢦⣄⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢀⡴⠻⠋⣺⣽⡿⠀⠀⠀⠀⣀⡀⠀⠀⠆⠀⠀⠀⠀⠀⠀⢠⣴⣦⣀⠀⠀⠀⠘⣿⣦⡀⠙⢷⣄⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⣀⣴⠟⠁⡠⣴⡇⡸⠁⠀⢠⣾⣿⣿⣿⣷⣠⠀⠀⠀⠀⠀⠀⠀⢼⣿⣿⣿⣿⣦⠀⠀⢸⠹⣷⣄⠀⠙⣿⡀⠀⠀⠀⠀
⠀⠀⢰⡞⠉⠁⠀⠤⠊⢠⡿⢱⠇⠀⠐⢛⡿⠿⠿⢿⡟⠁⠀⠀⠀⠀⠀⠀⠀⠈⢿⠛⣿⣿⠛⠁⠀⠹⡷⣿⡇⠳⢄⡈⠳⢶⣦⡀⠀
⠀⠠⣾⠃⠀⡀⠀⠀⠀⢸⡇⣿⠀⠀⠀⠀⠀⠀⣠⠊⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢢⠀⠀⠀⠀⠀⠀⠹⣿⡇⠀⢄⢈⠢⣀⣿⡷⠦
⠀⣼⡷⠀⢀⠔⠂⡰⠁⢈⡇⡇⠀⠀⠀⠀⢀⡴⠁⠀⠀⣠⣶⣶⣿⣿⣿⣶⣦⡀⠀⠀⠳⡀⠀⠀⠀⠀⠀⣿⣧⡀⠀⡙⠱⣌⢻⣿⡂
⠰⢿⣧⠞⢁⡤⠊⠀⠀⣼⣇⡇⠀⡠⠔⠊⠁⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀⠈⠑⠢⢄⠀⢠⣿⡟⡇⠠⡘⢦⠈⢺⣯⠁
⠀⠸⣿⠶⠋⣠⠎⢀⡞⠙⣿⡇⠀⡇⣸⡀⠀⠀⠀⠀⠀⠹⣿⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⣀⠈⡆⣸⣿⡻⠀⠀⠻⣄⡳⣼⣿⡀
⠀⠀⢿⣶⠏⢁⣶⠟⠀⠀⣿⣧⠀⠀⣿⣿⡄⠀⠀⠀⠀⠀⠈⠉⢻⣿⣛⠉⠀⠀⠀⠀⠀⢠⣾⣿⡆⠁⣿⡟⡇⠀⣦⡑⠂⣱⣿⣿⠇
⠀⠀⠈⢻⣷⡊⠀⢀⣀⢤⢿⡟⢴⠄⠘⣻⣿⣄⡀⠀⠀⠀⣀⣠⢿⡿⣄⣀⡀⠀⠀⠠⣴⢿⣿⡿⠁⢰⣿⡇⢣⠀⢌⣣⣷⠟⠁⠀⠀
⠀⠀⠀⠀⠙⣿⣿⣋⡿⢫⣿⣧⣰⠀⠀⢇⢻⣏⠉⡛⡟⠋⠉⠀⢸⡇⠀⠉⠉⣻⣿⠟⠁⢰⡟⠀⠀⣼⣿⣇⢠⡇⣸⠟⠏⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠘⠿⠿⠶⣿⢿⣿⡏⡄⠀⠈⣶⢿⡀⢸⣷⠀⠀⠀⠸⠀⠀⠀⢀⣿⡟⠀⢠⡿⠀⠀⣄⠹⠻⣿⣄⣹⠏⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣰⢸⡏⠀⢼⡟⢡⡀⠀⠸⣈⢷⡈⢻⡄⠀⠀⠀⠀⠀⠀⢸⡟⠁⢠⣿⠃⢸⣾⣿⠀⠀⢻⡙⠏⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢉⢸⠁⠀⠘⢇⣾⠁⠀⠀⠙⡆⠳⡌⢷⡀⠀⠀⠀⠀⣠⡟⣠⣶⡿⠃⠈⡈⠛⣇⠀⠀⢸⠧⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢸⣸⡆⠀⠀⢸⣡⣶⣇⠀⠀⠈⢦⡙⢦⡛⠶⠦⠤⠖⣫⣾⣿⡿⠀⣤⢠⣇⠀⠁⠀⢠⢿⡀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⣏⢿⡄⠀⠘⢻⣿⠿⡇⠀⠀⠀⠉⠪⣿⣿⣶⣶⣾⣟⡩⠀⠀⠀⣿⣼⡟⠀⠀⠀⡞⣤⠇⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠘⡌⣷⡀⠀⠈⢻⣴⣷⣶⠀⠀⠀⡀⠀⠉⠚⠓⠚⠁⠀⠀⠀⠐⣿⠿⠀⠀⠀⡸⢁⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⣎⠃⠀⠀⠀⠋⢃⣸⡺⠂⠀⣧⡼⢷⡄⢠⣄⡄⢀⣼⡟⣰⠻⠀⠀⠀⡰⢡⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠣⡀⠀⠀⠀⠛⠙⠁⠀⠘⠛⠁⢻⣿⠋⣿⡧⠈⢈⡴⠁⠀⠀⠀⠀⢁⠜⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⡞⠉⠀⠙⠁⠰⠋⠀⠀⠀⠀⠀⠴⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠒⠲⠀⠀⡀⠰⠐⠁⠐⡀⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀