### PR TITLE
Add show interface flap support

### DIFF
--- a/gnmi_server/interface_flap_cli_test.go
+++ b/gnmi_server/interface_flap_cli_test.go
@@ -1,0 +1,183 @@
+package gnmi
+
+// interface_flap_cli_test.go
+// Tests SHOW interface/flap
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetShowInterfaceFlap(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	expectedAll := `[{"Interface":"Ethernet0","Flap Count":"3","Admin":"Up","Oper":"Down","Link Down TimeStamp(UTC)":"2000","Link Up TimeStamp(UTC)":"1000"},{"Interface":"Ethernet1","Flap Count":"0","Admin":"Down","Oper":"Down","Link Down TimeStamp(UTC)":"1234","Link Up TimeStamp(UTC)":"Never"}]`
+	expectedSingle := `[{"Interface":"Ethernet0","Flap Count":"3","Admin":"Up","Oper":"Down","Link Down TimeStamp(UTC)":"2000","Link Up TimeStamp(UTC)":"1000"}]`
+	expectedAlias := `[{"Interface":"etp0","Flap Count":"3","Admin":"Up","Oper":"Down","Link Down TimeStamp(UTC)":"2000","Link Up TimeStamp(UTC)":"1000"},{"Interface":"Ethernet1","Flap Count":"0","Admin":"Down","Oper":"Down","Link Down TimeStamp(UTC)":"1234","Link Up TimeStamp(UTC)":"Never"}]`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+		mockPatch   func() *gomonkey.Patches
+		teardown    func()
+	}{
+		{
+			desc:       "query SHOW interface flap NO DATA",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+			testInit: func() {
+				// Ensure APPL DB empty
+				FlushDataSet(t, ApplDbNum)
+			},
+		},
+		{
+			desc:       "query SHOW interface flap (load appl port_table - all)",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" >
+            `,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedAll),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				AddDataSet(t, ApplDbNum, "../testdata/APPL_PORT_TABLE_FLAP.txt")
+			},
+		},
+		{
+			desc:       "query SHOW interface flap (load appl port_table - single interface)",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" key: { key: "interface" value: "Ethernet0" } >
+            `,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedSingle),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				AddDataSet(t, ApplDbNum, "../testdata/APPL_PORT_TABLE_FLAP.txt")
+			},
+		},
+		{
+			desc:       "query SHOW interface flap (alias display)",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" >
+            `,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedAlias),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				AddDataSet(t, ApplDbNum, "../testdata/APPL_PORT_TABLE_FLAP.txt")
+			},
+			mockPatch: func() *gomonkey.Patches {
+				p := gomonkey.ApplyFunc(sdc.PortToAliasNameMap, func() map[string]string {
+					return map[string]string{"Ethernet0": "etp0"}
+				})
+				os.Setenv(show_client.SonicCliIfaceMode, "alias")
+				return p
+			},
+			teardown: func() {
+				os.Setenv(show_client.SonicCliIfaceMode, "")
+			},
+		},
+		{
+			desc:       "query SHOW interface flap - invalid interface",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" key: { key: "interface" value: "Ethernet999" } >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+			// ensure port table empty -> invalid interface
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				AddDataSet(t, ApplDbNum, "../testdata/APPL_PORT_TABLE_FLAP.txt")
+			},
+		},
+		{
+			desc:       "query SHOW interface flap - GetMapFromQueries error",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "flap" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+			mockPatch: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					if len(queries) > 0 && len(queries[0]) > 1 && queries[0][0] == "APPL_DB" && queries[0][1] == show_client.AppDBPortTable {
+						return nil, fmt.Errorf("injected failure")
+					}
+					return map[string]interface{}{}, nil
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		// setup test dataset if provided
+		if test.testInit != nil {
+			test.testInit()
+		}
+
+		var patches *gomonkey.Patches
+		if test.mockPatch != nil {
+			patches = test.mockPatch()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+		if patches != nil {
+			patches.Reset()
+		}
+		if test.teardown != nil {
+			test.teardown()
+		}
+	}
+}

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -24,6 +24,7 @@ const AppDBPortChannelTable = "LAG_TABLE"
 const DefaultEmptyString = ""
 const StateDb = "STATE_DB"
 const ConfigDb = "CONFIG_DB"
+const ApplDb = "APPL_DB"
 const ConfigDbPort = "PORT"
 const FDBTable = "FDB_TABLE"
 const VlanSubInterfaceSeparator = '.'
@@ -408,4 +409,11 @@ func ContainsString(list []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func Capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -227,9 +227,9 @@ func init() {
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "system-memory"},
 		getSystemMemory,
-    nil,
+		nil,
 	)
-  sdc.RegisterCliPath(
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "lldp", "neighbors"},
 		getLLDPNeighbors,
 		nil,
@@ -247,5 +247,11 @@ func init() {
 		getUptime,
 		nil,
 		showCmdOptionVerbose,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "flap"},
+		getInterfaceFlap,
+		nil,
+		showCmdOptionInterface,
 	)
 }

--- a/testdata/APPL_PORT_TABLE_FLAP.txt
+++ b/testdata/APPL_PORT_TABLE_FLAP.txt
@@ -1,0 +1,16 @@
+{
+  "PORT_TABLE:Ethernet0": {
+    "flap_count": "3",
+    "admin_status": "up",
+    "oper_status": "down",
+    "last_up_time": "1000",
+    "last_down_time": "2000"
+  },
+  "PORT_TABLE:Ethernet1": {
+    "flap_count": "0",
+    "admin_status": "down",
+    "oper_status": "down",
+    "last_up_time": "Never",
+    "last_down_time": "1234"
+  }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Provide a gNMI SHOW getter that matches the existing CLI `show interface flap` so monitoring and automation can consume the same information via the gNMI API.

#### How I did it
- Added function `getInterfaceFlap` that:
 Queries APPL_DB PORT_TABLE.
 Optionally filters by an interface option (validates the interface exists).
 For each interface, extracts fields: flap_count, admin_status, oper_status, last_down_time, last_up_time.
- Add UT
#### (SHOW command specific) What sources are you using to fetch data?
`APPL_DB` → `PORT_TABLE`
Alias mapping: `sdc.PortToAliasNameMap()`
#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
<img width="1346" height="564" alt="image" src="https://github.com/user-attachments/assets/dbd731d8-56cd-4907-867d-fa9b6e971128" />


#### (Show command specific) Output of show CLI that is equivalent to API output
```
~$ show interface flap -h
Usage: show interface flap [OPTIONS] [INTERFACENAME]

  Show Interface Flap Information <interfacename>

Options:
  -h, -?, --help  Show this message and exit.
```

```
~$ show interface flap
Interface      Flap Count  Admin    Oper    Link Down TimeStamp(UTC)    Link Up TimeStamp(UTC)
-----------  ------------  -------  ------  --------------------------  ------------------------
Ethernet0               1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet4               1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet8               0  Down     Down    Never                       Never
Ethernet12              0  Down     Down    Never                       Never
Ethernet16              1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet20              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet24              0  Down     Down    Never                       Never
Ethernet28              0  Down     Down    Never                       Never
Ethernet32              0  Down     Down    Never                       Never
Ethernet36              0  Down     Down    Never                       Never
Ethernet40              0  Down     Down    Never                       Never
Ethernet44              0  Down     Down    Never                       Never
Ethernet48              0  Down     Down    Never                       Never
Ethernet52              0  Down     Down    Never                       Never
Ethernet56              0  Down     Down    Never                       Never
Ethernet60              0  Down     Down    Never                       Never
Ethernet64              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet68              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet72              0  Down     Down    Never                       Never
Ethernet76              0  Down     Down    Never                       Never
Ethernet80              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet84              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet88              0  Down     Down    Never                       Never
Ethernet92              0  Down     Down    Never                       Never
Ethernet96              1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet104             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet112             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet120             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet128             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet136             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet144             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet152             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet160             0  Down     Down    Never                       Never
Ethernet164             0  Down     Down    Never                       Never
Ethernet168             1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
Ethernet172             0  Down     Down    Never                       Never
Ethernet176             0  Down     Down    Never                       Never
Ethernet180             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet184             0  Down     Down    Never                       Never
Ethernet188             0  Down     Down    Never                       Never
Ethernet192             0  Down     Down    Never                       Never
Ethernet196             0  Down     Down    Never                       Never
Ethernet200             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet204             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet208             0  Down     Down    Never                       Never
Ethernet212             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet216             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet220             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet224             0  Down     Down    Never                       Never
Ethernet228             0  Down     Down    Never                       Never
Ethernet232             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet236             0  Down     Down    Never                       Never
Ethernet240             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet244             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet248             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
Ethernet252             1  Up       Up      Never                       Sat Aug 30 13:44:50 2025
```

```
~$ show interface flap Ethernet0
Interface      Flap Count  Admin    Oper    Link Down TimeStamp(UTC)    Link Up TimeStamp(UTC)
-----------  ------------  -------  ------  --------------------------  ------------------------
Ethernet0               1  Up       Up      Never                       Sat Aug 30 13:44:49 2025
```
#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```
:/# gnmi_get -xpath_target SHOW -xpath interface/flap -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "flap"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756722130536147814
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "flap"
      >
    >
    val: <
      json_ietf_val: "[{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet0\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet4\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet8\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet12\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet16\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet20\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet24\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet28\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet32\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet36\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet40\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet44\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet48\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet52\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet56\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet60\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet64\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet68\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet72\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet76\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet80\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet84\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet88\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet92\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet96\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet104\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet112\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet120\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet128\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet136\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet144\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet152\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet160\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet164\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet168\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet172\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet176\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet180\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet184\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet188\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet192\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet196\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet200\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet204\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet208\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet212\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet216\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet220\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet224\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet228\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet232\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Down\",\"Flap Count\":\"0\",\"Interface\":\"Ethernet236\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Down\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet240\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet244\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet248\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet252\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:50 2025\",\"Oper\":\"Up\"},{\"Admin\":\"Unknown\",\"Flap Count\":\"Never\",\"Interface\":\"PortConfigDone\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Unknown\"},{\"Admin\":\"Unknown\",\"Flap Count\":\"Never\",\"Interface\":\"PortInitDone\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Never\",\"Oper\":\"Unknown\"}]"
    >
  >
>

```

```
/# gnmi_get -target_addr 127.0.0.1:50051 -insecure -logtostderr -xpath_target SHOW -encoding JSON_IETF -xpath 'interface/flap[interface=Ethernet0]'
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "flap"
    key: <
      key: "interface"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756722189387370860
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "flap"
        key: <
          key: "interface"
          value: "Ethernet0"
        >
      >
    >
    val: <
      json_ietf_val: "[{\"Admin\":\"Up\",\"Flap Count\":\"1\",\"Interface\":\"Ethernet0\",\"Link Down TimeStamp(UTC)\":\"Never\",\"Link Up TimeStamp(UTC)\":\"Sat Aug 30 13:44:49 2025\",\"Oper\":\"Up\"}]"
    >
  >
>

```
#### A picture of a cute animal (not mandatory but encouraged)
