### PR TITLE
Add show interface naming_mode

### DIFF
--- a/gnmi_server/interface_naming_mode_cli_test.go
+++ b/gnmi_server/interface_naming_mode_cli_test.go
@@ -1,0 +1,99 @@
+package gnmi
+
+// interface_naming_mode_cli_test.go
+// Tests SHOW interface/naming_mode
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetShowInterfaceNamingMode(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	expectedDefault := `{"naming_mode":"default"}`
+	expectedAlias := `{"naming_mode":"alias"}`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+		teardown    func()
+	}{
+		{
+			desc:       "query SHOW interface naming_mode (default)",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "naming_mode" >
+            `,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedDefault),
+			valTest:     true,
+			testInit: func() {
+				// ensure no env override
+				_ = os.Unsetenv(show_client.SonicCliIfaceMode)
+			},
+		},
+		{
+			desc:       "query SHOW interface naming_mode (alias)",
+			pathTarget: "SHOW",
+			textPbPath: `
+                elem: <name: "interface" >
+                elem: <name: "naming_mode" >
+            `,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedAlias),
+			valTest:     true,
+			testInit: func() {
+				os.Setenv(show_client.SonicCliIfaceMode, "alias")
+			},
+			teardown: func() {
+				_ = os.Unsetenv(show_client.SonicCliIfaceMode)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+		if test.teardown != nil {
+			test.teardown()
+		}
+	}
+}

--- a/gnmi_server/interface_naming_mode_cli_test.go
+++ b/gnmi_server/interface_naming_mode_cli_test.go
@@ -5,7 +5,6 @@ package gnmi
 
 import (
 	"crypto/tls"
-	"os"
 	"testing"
 	"time"
 
@@ -46,8 +45,8 @@ func TestGetShowInterfaceNamingMode(t *testing.T) {
 		wantRetCode codes.Code
 		wantRespVal interface{}
 		valTest     bool
-		testInit    func()
-		teardown    func()
+		envKey      string
+		envVal      string
 	}{
 		{
 			desc:       "query SHOW interface naming_mode (default)",
@@ -59,10 +58,8 @@ func TestGetShowInterfaceNamingMode(t *testing.T) {
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(expectedDefault),
 			valTest:     true,
-			testInit: func() {
-				// ensure no env override
-				_ = os.Unsetenv(show_client.SonicCliIfaceMode)
-			},
+			envKey:      show_client.SonicCliIfaceMode,
+			envVal:      "",
 		},
 		{
 			desc:       "query SHOW interface naming_mode (alias)",
@@ -74,26 +71,17 @@ func TestGetShowInterfaceNamingMode(t *testing.T) {
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(expectedAlias),
 			valTest:     true,
-			testInit: func() {
-				os.Setenv(show_client.SonicCliIfaceMode, "alias")
-			},
-			teardown: func() {
-				_ = os.Unsetenv(show_client.SonicCliIfaceMode)
-			},
+			envKey:      show_client.SonicCliIfaceMode,
+			envVal:      "alias",
 		},
 	}
 
 	for _, test := range tests {
-		if test.testInit != nil {
-			test.testInit()
-		}
-
 		t.Run(test.desc, func(t *testing.T) {
+			if test.envKey != "" {
+				t.Setenv(test.envKey, test.envVal)
+			}
 			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
 		})
-
-		if test.teardown != nil {
-			test.teardown()
-		}
 	}
 }

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -30,6 +30,10 @@ type InterfaceCountersResponse struct {
 	TxOvr  string
 }
 
+type namingModeResponse struct {
+	NamingMode string `json:"naming_mode"`
+}
+
 func calculateByteRate(rate string) string {
 	if rate == defaultMissingCounterValue {
 		return defaultMissingCounterValue
@@ -1265,4 +1269,10 @@ func getInterfaceNeighborExpected(options sdc.OptionMap) ([]byte, error) {
 	}
 
 	return json.Marshal(out)
+}
+
+func getInterfaceNamingMode(options sdc.OptionMap) ([]byte, error) {
+	mode := GetInterfaceNamingMode()
+	namingModeResp := namingModeResponse{NamingMode: mode}
+	return json.Marshal(namingModeResp)
 }

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -340,7 +340,7 @@ func GetInterfaceNameForDisplay(name string) string {
 	if name == "" {
 		return name
 	}
-	if interfaceNamingMode := os.Getenv(SonicCliIfaceMode); interfaceNamingMode != "alias" {
+	if interfaceNamingMode := GetInterfaceNamingMode(); interfaceNamingMode != "alias" {
 		return name
 	}
 
@@ -431,4 +431,11 @@ func Capitalize(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
+}
+
+func GetInterfaceNamingMode() string {
+	if mode := os.Getenv(SonicCliIfaceMode); mode != "" {
+		return mode
+	}
+	return "default"
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -287,4 +287,10 @@ func init() {
 		getInterfaceNeighborExpected,
 		nil,
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "naming_mode"},
+		getInterfaceNamingMode,
+		nil,
+		showCmdOptionVerbose,
+	)
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Provide parity between the Python CLI `show interfaces naming_mode` and the gNMI SHOW path so consumers using the gNMI API see the same naming-mode information as the CLI.

#### How I did it
- Implemented the gNMI handler `getInterfaceNamingMode` so it reads the environment value SONIC_CLI_IFACE_MODE. Falls back to "default" when not set, and returns JSON: {"naming_mode":"<value>"}.
- Added a unit test `TestGetShowInterfaceNamingMode` that:
Ensures default case when SONIC_CLI_IFACE_MODE is not set → returns {"naming_mode":"default"}.
Ensures alias case when SONIC_CLI_IFACE_MODE=alias → returns {"naming_mode":"alias"}.

#### (SHOW command specific) What sources are you using to fetch data?
The naming_mode SHOW command uses no DB tables — it relies exclusively on the environment variable SONIC_CLI_IFACE_MODE. (This mirrors clicommon.get_interface_naming_mode() in utilities, which calls `os.getenv('SONIC_CLI_IFACE_MODE')` and returns "default" when unset.)

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
<img width="692" height="484" alt="image" src="https://github.com/user-attachments/assets/1a4d9cfa-d833-4c8c-9477-beffbc3ee273" />

#### (Show command specific) Output of show CLI that is equivalent to API output
```
:~$ show interface naming_mode -h
Usage: show interface naming_mode [OPTIONS]

  Show interface naming_mode status

Options:
  --verbose       Enable verbose output
  -h, -?, --help  Show this message and exit.

:~$ show interface naming_mode
default

:~$ show interface naming_mode --verbose
default
```
#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```
:/# gnmi_get -xpath_target SHOW -xpath interface/naming_mode -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "naming_mode"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756889644031870325
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "naming_mode"
      >
    >
    val: <
      json_ietf_val: "{\"naming_mode\":\"default\"}"
    >
  >
>

```
#### A picture of a cute animal (not mandatory but encouraged)
