### PR TITLE
Fix the show headroom_pool command typo

### DIFF
--- a/gnmi_server/headroom_pool_cli_test.go
+++ b/gnmi_server/headroom_pool_cli_test.go
@@ -43,25 +43,25 @@ func TestShowHeadroomPoolWatermarks(t *testing.T) {
 	AddDataSet(t, CountersDbNum, userWatermarksFile)
 	AddDataSet(t, CountersDbNum, persistentWatermarksFile)
 
-	// SHOW headroom_pool watermark
-	t.Run("query SHOW headroom_pool watermark", func(t *testing.T) {
+	// SHOW headroom-pool watermark
+	t.Run("query SHOW headroom-pool watermark", func(t *testing.T) {
 		textPbPath := `
-            elem: <name: "headroom_pool" >
+            elem: <name: "headroom-pool" >
             elem: <name: "watermark" >
         `
-		t.Log("Sending GET for SHOW/headroom_pool/watermark (user watermarks)")
+		t.Log("Sending GET for SHOW/headroom-pool/watermark (user watermarks)")
 		// Only ingress_lossless_pool should be included
 		expectedJSON := `{"ingress_lossless_pool":{"Bytes":"3333"}}`
 		runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, []byte(expectedJSON), true)
 	})
 
-	// SHOW headroom_pool persistent-watermark
-	t.Run("query SHOW headroom_pool persistent-watermark", func(t *testing.T) {
+	// SHOW headroom-pool persistent-watermark
+	t.Run("query SHOW headroom-pool persistent-watermark", func(t *testing.T) {
 		textPbPath := `
-            elem: <name: "headroom_pool" >
+            elem: <name: "headroom-pool" >
             elem: <name: "persistent-watermark" >
         `
-		t.Log("Sending GET for SHOW/headroom_pool/persistent-watermark (persistent watermarks)")
+		t.Log("Sending GET for SHOW/headroom-pool/persistent-watermark (persistent watermarks)")
 		expectedJSON := `{"ingress_lossless_pool":{"Bytes":"9999"}}`
 		runTestGet(t, ctx, gClient, "SHOW", textPbPath, codes.OK, []byte(expectedJSON), true)
 	})

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -100,13 +100,13 @@ func init() {
 		sdc.UnimplementedOption(showCmdOptionDisplay),
 	)
 	sdc.RegisterCliPath(
-		[]string{"SHOW", "headroom_pool", "watermark"},
+		[]string{"SHOW", "headroom-pool", "watermark"},
 		getHeadroomPoolWatermark,
 		nil,
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 	)
 	sdc.RegisterCliPath(
-		[]string{"SHOW", "headroom_pool", "persistent-watermark"},
+		[]string{"SHOW", "headroom-pool", "persistent-watermark"},
 		getHeadroomPoolPersistentWatermark,
 		nil,
 		sdc.UnimplementedOption(showCmdOptionNamespace),


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As the cli uses headroom-pool instead of headroom_pool.

#### How I did it
Update headroom_pool to headroom-pool

#### (SHOW command specific) What sources are you using to fetch data?
NA

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
UT and DUT

#### (Show command specific) Output of show CLI that is equivalent to API output
```
:~$ show headroom-pool watermark
Headroom pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0
```

```
:~$ show headroom-pool persistent-watermark
Headroom pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0
```

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```
:/# gnmi_get -xpath_target SHOW -xpath headroom-pool/watermark -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "headroom-pool"
  >
  elem: <
    name: "watermark"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756966443661846319
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "headroom-pool"
      >
      elem: <
        name: "watermark"
      >
    >
    val: <
      json_ietf_val: "{\"ingress_lossless_pool\":{\"Bytes\":\"0\"}}"
    >
  >
>
```

```
:/# gnmi_get -xpath_target SHOW -xpath headroom-pool/persistent-watermark  -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "headroom-pool"
  >
  elem: <
    name: "persistent-watermark"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1756966454240726636
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "headroom-pool"
      >
      elem: <
        name: "persistent-watermark"
      >
    >
    val: <
      json_ietf_val: "{\"ingress_lossless_pool\":{\"Bytes\":\"0\"}}"
    >
  >
>
```
#### A picture of a cute animal (not mandatory but encouraged)
<img width="300" height="363" alt="Screenshot 2025-09-02 153816(mid)" src="https://github.com/user-attachments/assets/cab553f0-fc38-41bf-b20e-b611493be265" />
