### PR TITLE
Add SHOW implementation for interface transceiver eeprom

### DIFF
--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -37,7 +37,7 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 	defer cancel()
 
 	transceiverErrorStatusFileName := "../testdata/TRANSCEIVER_STATUS_SW.txt"
-	transceiverErrorStatus := `{"Ethernet90":{"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet91": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet92": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet93": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet94": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet95": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet96": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet97": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet98": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet99": {"cmis_state": "READY","error": "N/A","status": "1"}}`
+	transceiverErrorStatus := `{"Ethernet0":{"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet40": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet80": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet120": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet160": {"cmis_state": "READY","error": "N/A","status": "1"}}`
 	transceiverErrorStatusPort := `{"cmis_state": "READY","error": "N/A","status": "1"}`
 	ResetDataSetsAndMappings(t)
 
@@ -92,7 +92,7 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 			textPbPath: `
 				elem: <name: "interface" >
 				elem: <name: "transceiver" >
-				elem: <name: "error-status" key: { key: "interface" value: "Ethernet90" }>
+				elem: <name: "error-status" key: { key: "interface" value: "Ethernet80" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(transceiverErrorStatusPort),
@@ -101,6 +101,238 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 				FlushDataSet(t, StateDbNum)
 				AddDataSet(t, StateDbNum, transceiverErrorStatusFileName)
 			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+	}
+}
+
+func TestGetTransceiverEEPROM(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	portTableFileName := "../testdata/TRANSCEIVER_PORT_TABLE.txt"
+	portsFileName := "../testdata/TRANSCEIVER_PORTS.txt"
+	transceiverInfoFileName := "../testdata/TRANSCEIVER_INFO.txt"
+	transceiverFirmwareInfoFileName := "../testdata/TRANSCEIVER_FIRMWARE_INFO.txt"
+	transceiverDomSensorFileName := "../testdata/TRANSCEIVER_DOM_SENSOR.txt"
+	transceiverDomThresholdFileName := "../testdata/TRANSCEIVER_DOM_THRESHOLD.txt"
+	transceiverErrorStatusFileName := "../testdata/TRANSCEIVER_STATUS_SW.txt"
+
+	transceiverEEPROM := ``
+	transceiverEEPROMPort := ``
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW interface transceiver eeprom read error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" >
+			`,
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:       "query SHOW interface transceiver eeprom NO interface dataset",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" >
+			`,
+			wantRetCode: codes.OK,
+		},
+		{
+			desc:       "query SHOW interface transceiver eeprom",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverEEPROM),
+			valTest:     false,
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				FlushDataSet(t, ConfigDbNum)
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, ApplDbNum, portTableFileName)
+				AddDataSet(t, ConfigDbNum, portsFileName)
+				AddDataSet(t, StateDbNum, transceiverInfoFileName)
+				AddDataSet(t, StateDbNum, transceiverFirmwareInfoFileName)
+				AddDataSet(t, StateDbNum, transceiverDomSensorFileName)
+				AddDataSet(t, StateDbNum, transceiverDomThresholdFileName)
+				AddDataSet(t, StateDbNum, transceiverErrorStatusFileName)
+			},
+		},
+		{
+			desc:       "query SHOW interface transceiver eeprom port option",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" key: { key: "port" value: "Ethernet40" }>
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverEEPROMPort),
+			valTest:     false,
+		},
+		{
+			desc:       "query SHOW interface transceiver eeprom dom option",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" key: { key: "dom" value: "true" }>
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverEEPROMPort),
+			valTest:     false,
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+	}
+}
+
+func TestGetTransceiverInfo(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	portTableFileName := "../testdata/TRANSCEIVER_PORT_TABLE.txt"
+	portsFileName := "../testdata/TRANSCEIVER_PORTS.txt"
+	transceiverInfoFileName := "../testdata/TRANSCEIVER_INFO.txt"
+	transceiverFirmwareInfoFileName := "../testdata/TRANSCEIVER_FIRMWARE_INFO.txt"
+	transceiverDomSensorFileName := "../testdata/TRANSCEIVER_DOM_SENSOR.txt"
+	transceiverDomThresholdFileName := "../testdata/TRANSCEIVER_DOM_THRESHOLD.txt"
+	transceiverErrorStatusFileName := "../testdata/TRANSCEIVER_STATUS_SW.txt"
+
+	transceiverEEPROM := ``
+	transceiverEEPROMPort := ``
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW interface transceiver info read error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "" >
+				elem: <name: "transceiver" >
+				elem: <name: "info" >
+			`,
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:       "query SHOW interface transceiver info NO interface dataset",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "info" >
+			`,
+			wantRetCode: codes.OK,
+		},
+		{
+			desc:       "query SHOW interface transceiver info",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "info" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverEEPROM),
+			valTest:     false,
+			testInit: func() {
+				FlushDataSet(t, ApplDbNum)
+				FlushDataSet(t, ConfigDbNum)
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, ApplDbNum, portTableFileName)
+				AddDataSet(t, ConfigDbNum, portsFileName)
+				AddDataSet(t, StateDbNum, transceiverInfoFileName)
+				AddDataSet(t, StateDbNum, transceiverFirmwareInfoFileName)
+				AddDataSet(t, StateDbNum, transceiverDomSensorFileName)
+				AddDataSet(t, StateDbNum, transceiverDomThresholdFileName)
+				AddDataSet(t, StateDbNum, transceiverErrorStatusFileName)
+			},
+		},
+		{
+			desc:       "query SHOW interface transceiver info port option",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "eeprom" key: { key: "port" value: "Ethernet40" }>
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverEEPROMPort),
+			valTest:     false,
 		},
 	}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### (SHOW command specific) What sources are you using to fetch data?

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)

```
root@str5-7060x6-512-5:/# gnmi_get -xpath_target SHOW -xpath interface/transceiver/eeprom[port=Ethernet0] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "transceiver"
  >
  elem: <
    name: "eeprom"
    key: <
      key: "port"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF


== getResponse:
notification: <
  timestamp: 1756797870398444468
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "transceiver"
      >
      elem: <
        name: "eeprom"
        key: <
          key: "port"
          value: "Ethernet0"
        >
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0\":\"SFP EEPROM detected\\n        Active application selected code assigned to host lane 1: N/A\\n        Active application selected code assigned to host lane 2: N/A\\n        Active application selected code assigned to host lane 3: N/A\\n        Active application selected code assigned to host lane 4: N/A\\n        Active application selected code assigned to host lane 5: N/A\\n        Active application selected code assigned to host lane 6: N/A\\n        Active application selected code assigned to host lane 7: N/A\\n        Active application selected code assigned to host lane 8: N/A\\n        Application Advertisement: 800G-ETC-CR8 - Host Assign (0x1) - Copper cable - Media Assign (Unknown)\\n                                   400GBASE-CR4 (Clause 162) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)\\n                                   400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (Unknown)\\n                                   200GBASE-CR4 (Clause 136) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)\\n                                   100GBASE-CR4 (Clause 92) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)\\n                                   40GBASE-CR4 (Clause 85) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)\\n        CMIS Rev: 5.0\\n        Connector: No separable connector\\n        Encoding: N/A\\n        Extended Identifier: Power Class 1 (0.25W Max)\\n        Extended RateSelect Compliance: N/A\\n        Host Lane Count: 8\\n        Identifier: OSFP 8X Pluggable Transceiver\\n        Length Cable Assembly(m): 1.0\\n        Media Interface Technology: Copper cable unequalized\\n        Media Lane Count: 0\\n        Module Hardware Rev: 0.0\\n        Nominal Bit Rate(100Mbs): N/A\\n        Specification compliance: passive_copper_media_interface\\n        Vendor Date Code(YYYY-MM-DD Lot): 2024-11-25\\n        Vendor Name: Amphenol\\n        Vendor OUI: 78-a7-14\\n        Vendor PN: NJMMER-M201\\n        Vendor Rev: A\\n        Vendor SN: APF2447201229A\\n\"}"
    >
  >
>

```

<img width="506" height="476" alt="image" src="https://github.com/user-attachments/assets/d7c63c05-a206-4695-b86a-d5ae34b773a7" />


#### (Show command specific) Output of show CLI that is equivalent to API output

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

#### A picture of a cute animal (not mandatory but encouraged)
