### PR TITLE
Remove redundant helper function toString from show_common.go

### DIFF
--- a/show_client/dropstat_cli.go
+++ b/show_client/dropstat_cli.go
@@ -318,7 +318,7 @@ func getAlias(counterName string) string {
 		return counterName
 	}
 
-	aliasVal := toString(getOrDefault(aliasQuery, "alias", interface{}(counterName)))
+	aliasVal := fmt.Sprint(getOrDefault(aliasQuery, "alias", interface{}(counterName)))
 	return aliasVal
 }
 
@@ -340,7 +340,7 @@ func inGroup(counterStat string, objectStatMap string, group string) bool {
 		return false
 	}
 
-	return group == toString(getOrDefault(group_query, "group", ""))
+	return group == fmt.Sprint(getOrDefault(group_query, "group", ""))
 }
 
 // Checks whether the type of the given counter_stat is the same as counter_type.
@@ -362,7 +362,7 @@ func isType(counterStat string, objectStatMap string, counterType string) bool {
 		return false
 	}
 
-	return counterType == toString(getOrDefault(typeQuery, "type", ""))
+	return counterType == fmt.Sprint(getOrDefault(typeQuery, "type", ""))
 }
 
 // getEntry returns the CONFIG_DB DEBUG_COUNTER row for a given counterName.

--- a/show_client/mac_cli.go
+++ b/show_client/mac_cli.go
@@ -180,7 +180,7 @@ func processFDBData(data map[string]interface{}, addIfMatch func(int, string, st
 		if !ok {
 			continue
 		}
-		addIfMatch(vlan, mac, toString(fv["port"]), toString(fv["type"]))
+		addIfMatch(vlan, mac, fmt.Sprint(fv["port"]), fmt.Sprint(fv["type"]))
 	}
 }
 

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -309,16 +309,6 @@ func natsortInterfaces(interfaces []string) []string {
 	return interfaces
 }
 
-// toString converts any value to string, returning the value directly if it is already a string.
-func toString(v interface{}) string {
-	switch x := v.(type) {
-	case string:
-		return x
-	default:
-		return fmt.Sprint(v)
-	}
-}
-
 func GetSortedKeys(m map[string]interface{}) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/show_client/watermark_pool_helper.go
+++ b/show_client/watermark_pool_helper.go
@@ -65,7 +65,7 @@ func collectBufferPoolWatermarks(pools map[string]string, tableName string, fiel
 
 		bytes := defaultMissingCounterValue
 		if val, ok := data[fieldName]; ok {
-			bytes = toString(val)
+			bytes = fmt.Sprint(val)
 		} else {
 			log.Errorf("Missing field %s in %s for pool %s oid %s -> Bytes=%s", fieldName, tableName, pool, oid, bytes)
 		}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To remove unnecessary helper functions which could help restructure common subpackage in show_client.

#### How I did it
Remove toString() helper from show_client.go and use fmt.Sprint() directly for all its references.

#### (SHOW command specific) What sources are you using to fetch data?
N/A

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
N/A

#### (Show command specific) Output of show CLI that is equivalent to API output
N/A

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A
