### PR TITLE
Fix show interfaces neighbor expected

### DIFF
--- a/gnmi_server/interface_neighbor_expected_cli_test.go
+++ b/gnmi_server/interface_neighbor_expected_cli_test.go
@@ -1,6 +1,6 @@
 package gnmi
 
-// Tests SHOW interface neighbor expected (JSON output)
+// Enriched tests for SHOW/interfaces/neighbor/expected
 
 import (
 	"crypto/tls"
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -19,16 +18,16 @@ import (
 )
 
 // getInterfaceNeighborExpected returns JSON like:
-// {
-//   "Ethernet2": {
-//     "neighbor":"DEVICE01T1",
-//     "neighbor_port":"Ethernet1",
-//     "neighbor_loopback":"10.1.1.1",
-//     "neighbor_mgmt":"192.0.2.10",
-//     "neighbor_type":"BackEndLeafRouter"
-//   }
-// }
-
+//
+//	{
+//	  "Ethernet2": {
+//	    "neighbor":"DEVICE01T1",
+//	    "neighbor_port":"Ethernet1",
+//	    "neighbor_loopback":"10.1.1.1",
+//	    "neighbor_mgmt":"192.0.2.10",
+//	    "neighbor_type":"BackEndLeafRouter"
+//	  }
+//	}
 func TestShowInterfaceNeighborExpected(t *testing.T) {
 	s := createServer(t, ServerPort)
 	go runServer(t, s)
@@ -47,96 +46,133 @@ func TestShowInterfaceNeighborExpected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
 	defer cancel()
 
-	neighborFile := "../testdata/DEVICE_NEIGHBOR_EXPECTED.txt"
-	neighborMetaFile := "../testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt"
-	neighborOnlyFile := "../testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt"
+	basePath := `
+      elem: <name:"interfaces">
+      elem: <name:"neighbor">
+      elem: <name:"expected">
+    `
 
-	const (
-		expectedEmpty       = `{}`
-		expectedSingle      = `{"Ethernet2":{"Neighbor":"DEVICE01T1","NeighborPort":"Ethernet1","NeighborLoopback":"10.1.1.1","NeighborMgmt":"192.0.2.10","NeighborType":"BackEndLeafRouter"}}`
-		expectedMissingMeta = `{"Ethernet4":{"Neighbor":"DEVICE02T1","NeighborPort":"Ethernet9","NeighborLoopback":"None","NeighborMgmt":"None","NeighborType":"None"}}`
-	)
+	fullDataFile := "../testdata/NEIGHBOR_EXPECTED_FULL.txt"
+	minDataFile := "../testdata/NEIGHBOR_EXPECTED_MIN.txt"
 
-	tests := []struct {
-		desc       string
-		init       func()
-		textPbPath string
-		wantCode   codes.Code
-		wantVal    []byte
-		valTest    bool
-	}{
+	const expectedEmpty = `{}`
+
+	type tc struct {
+		desc     string
+		envMode  string
+		init     func()
+		addArg   string // optional single interface argument (alias or canonical)
+		wantCode codes.Code
+		wantVal  []byte
+		valTest  bool
+	}
+
+	tests := []tc{
 		{
-			desc: "no data",
+			desc:    "empty tables default mode -> {}",
+			envMode: "",
 			init: func() {
-				FlushDataSet(t, ConfigDbNum)
+				// no data loaded
 			},
-			textPbPath: `
-              elem: <name: "interfaces">
-              elem: <name: "neighbor">
-              elem: <name: "expected">
-            `,
 			wantCode: codes.OK,
-			wantVal:  []byte(expectedEmpty),
+			wantVal:  []byte(`{}`),
 			valTest:  true,
 		},
 		{
-			desc: "single neighbor (datasets)",
+			desc:    "all neighbors default mode (canonical keys)",
+			envMode: "",
 			init: func() {
-				FlushDataSet(t, ConfigDbNum)
-				AddDataSet(t, ConfigDbNum, neighborFile)
-				AddDataSet(t, ConfigDbNum, neighborMetaFile)
+				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			textPbPath: `
-              elem: <name: "interfaces">
-              elem: <name: "neighbor">
-              elem: <name: "expected">
-            `,
 			wantCode: codes.OK,
-			wantVal:  []byte(expectedSingle),
+			// Keys are canonical (Ethernet0, Ethernet2)
+			wantVal: []byte(`{"Ethernet0":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"},"Ethernet2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
+			valTest: true,
+		},
+		{
+			desc:    "all neighbors alias mode (alias keys)",
+			envMode: "alias",
+			init: func() {
+				AddDataSet(t, ConfigDbNum, fullDataFile)
+			},
+			wantCode: codes.OK,
+			wantVal:  []byte(`{"etp1":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"},"etp2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
 			valTest:  true,
 		},
 		{
-			desc: "missing metadata defaults (datasets)",
+			desc:    "single interface alias mode valid alias",
+			envMode: "alias",
 			init: func() {
-				FlushDataSet(t, ConfigDbNum)
-				AddDataSet(t, ConfigDbNum, neighborOnlyFile)
+				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			textPbPath: `
-              elem: <name: "interfaces">
-              elem: <name: "neighbor">
-              elem: <name: "expected">
-            `,
+			addArg:   "etp1",
 			wantCode: codes.OK,
-			wantVal:  []byte(expectedMissingMeta),
+			wantVal:  []byte(`{"etp1":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"}}`),
 			valTest:  true,
 		},
 		{
-			desc: "GetMapFromQueries error (neighbor)",
+			desc:    "single interface default mode canonical",
+			envMode: "",
 			init: func() {
-				FlushDataSet(t, ConfigDbNum)
-				patch := gomonkey.ApplyFunc(show_client.GetMapFromQueries,
-					func(q [][]string) (map[string]interface{}, error) {
-						return nil, fmt.Errorf("injected neighbor error")
-					})
-				t.Cleanup(func() { patch.Reset() })
+				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			textPbPath: `
-              elem: <name: "interfaces">
-              elem: <name: "neighbor">
-              elem: <name: "expected">
-            `,
-			wantCode: codes.NotFound,
+			addArg:   "Ethernet2",
+			wantCode: codes.OK,
+			wantVal:  []byte(`{"Ethernet2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
+			valTest:  true,
+		},
+		{
+			desc:    "alias mode invalid canonical should error",
+			envMode: "alias",
+			init: func() {
+				AddDataSet(t, ConfigDbNum, fullDataFile)
+			},
+			addArg:   "Ethernet0",
+			wantCode: codes.InvalidArgument,
 			valTest:  false,
+		},
+		{
+			desc:    "alias mode invalid alias",
+			envMode: "alias",
+			init: func() {
+				AddDataSet(t, ConfigDbNum, fullDataFile)
+			},
+			addArg:   "etp9",
+			wantCode: codes.InvalidArgument,
+			valTest:  false,
+		},
+		{
+			desc:    "missing metadata fields -> None defaults",
+			envMode: "alias",
+			init: func() {
+				AddDataSet(t, ConfigDbNum, minDataFile)
+			},
+			wantCode: codes.OK,
+			wantVal:  []byte(`{"etp3":{"Neighbor":"DeviceC","NeighborPort":"Ethernet12","NeighborLoopback":"None","NeighborMgmt":"None","NeighborType":"None"}}`),
+			valTest:  true,
 		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			ResetDataSetsAndMappings(t)
+			if tc.envMode != "" {
+				t.Setenv(show_client.SonicCliIfaceMode, tc.envMode)
+			} else {
+				t.Setenv(show_client.SonicCliIfaceMode, "")
+			}
 			if tc.init != nil {
 				tc.init()
 			}
-			runTestGet(t, ctx, gClient, "SHOW", tc.textPbPath, tc.wantCode, tc.wantVal, tc.valTest)
+
+			// Build path (append interface arg element if needed)
+			path := basePath
+			if tc.addArg != "" {
+				path += fmt.Sprintf(`elem: <name:"%s">`, tc.addArg)
+			}
+
+			runTestGet(t, ctx, gClient, "SHOW", path, tc.wantCode, tc.wantVal, tc.valTest)
 		})
 	}
 }

--- a/gnmi_server/interface_neighbor_expected_cli_test.go
+++ b/gnmi_server/interface_neighbor_expected_cli_test.go
@@ -148,7 +148,7 @@ func TestShowInterfaceNeighborExpected(t *testing.T) {
 				AddDataSet(t, ConfigDbNum, minDataFile)
 			},
 			wantCode: codes.OK,
-			wantVal:  []byte(`{"etp3":{"Neighbor":"DeviceC","NeighborPort":"Ethernet12","NeighborLoopback":"None","NeighborMgmt":"None","NeighborType":"None"}}`),
+			wantVal:  []byte(`{}`),
 			valTest:  true,
 		},
 	}

--- a/gnmi_server/interface_neighbor_expected_cli_test.go
+++ b/gnmi_server/interface_neighbor_expected_cli_test.go
@@ -1,10 +1,9 @@
 package gnmi
 
-// Enriched tests for SHOW/interfaces/neighbor/expected
+// Tests for SHOW/interfaces/neighbor/expected
 
 import (
 	"crypto/tls"
-	"fmt"
 	"testing"
 	"time"
 
@@ -13,8 +12,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-
-	show_client "github.com/sonic-net/sonic-gnmi/show_client"
 )
 
 // getInterfaceNeighborExpected returns JSON like:
@@ -35,118 +32,143 @@ func TestShowInterfaceNeighborExpected(t *testing.T) {
 	defer ResetDataSetsAndMappings(t)
 
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
-	conn, err := grpc.Dial(TargetAddr, opts...)
+	conn, err := grpc.Dial(TargetAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
 	defer conn.Close()
-
 	gClient := pb.NewGNMIClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
-	defer cancel()
-
-	basePath := `
-      elem: <name:"interfaces">
-      elem: <name:"neighbor">
-      elem: <name:"expected">
-    `
 
 	fullDataFile := "../testdata/NEIGHBOR_EXPECTED_FULL.txt"
 	minDataFile := "../testdata/NEIGHBOR_EXPECTED_MIN.txt"
 
-	const expectedEmpty = `{}`
-
 	type tc struct {
-		desc     string
-		envMode  string
-		init     func()
-		addArg   string // optional single interface argument (alias or canonical)
-		wantCode codes.Code
-		wantVal  []byte
-		valTest  bool
+		desc       string
+		init       func()
+		pathTarget string
+		textPbPath string
+		wantCode   codes.Code
+		wantVal    []byte
+		valTest    bool
 	}
 
 	tests := []tc{
 		{
-			desc:    "empty tables default mode -> {}",
-			envMode: "",
-			init: func() {
-				// no data loaded
-			},
+			desc:       "empty tables default mode -> {}",
+			init:       func() {},
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected">
+            `,
 			wantCode: codes.OK,
 			wantVal:  []byte(`{}`),
 			valTest:  true,
 		},
 		{
-			desc:    "all neighbors default mode (canonical keys)",
-			envMode: "",
+			desc: "all neighbors default mode (canonical keys)",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected">
+            `,
 			wantCode: codes.OK,
-			// Keys are canonical (Ethernet0, Ethernet2)
-			wantVal: []byte(`{"Ethernet0":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"},"Ethernet2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
-			valTest: true,
+			wantVal:  []byte(`{"Ethernet0":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"},"Ethernet2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
+			valTest:  true,
 		},
 		{
-			desc:    "all neighbors alias mode (alias keys)",
-			envMode: "alias",
+			desc: "all neighbors alias mode (alias keys)",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected" key:{ key:"SONIC_CLI_IFACE_MODE" value:"alias" } >
+            `,
 			wantCode: codes.OK,
 			wantVal:  []byte(`{"etp1":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"},"etp2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
 			valTest:  true,
 		},
 		{
-			desc:    "single interface alias mode valid alias",
-			envMode: "alias",
+			desc: "single interface alias mode valid alias",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			addArg:   "etp1",
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected" key:{ key:"SONIC_CLI_IFACE_MODE" value:"alias" } >
+              elem: <name:"etp1">
+            `,
 			wantCode: codes.OK,
 			wantVal:  []byte(`{"etp1":{"Neighbor":"DeviceA","NeighborPort":"Ethernet10","NeighborLoopback":"10.0.0.1","NeighborMgmt":"192.168.0.1","NeighborType":"Leaf"}}`),
 			valTest:  true,
 		},
 		{
-			desc:    "single interface default mode canonical",
-			envMode: "",
+			desc: "single interface default mode canonical",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			addArg:   "Ethernet2",
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected">
+              elem: <name:"Ethernet2">
+            `,
 			wantCode: codes.OK,
 			wantVal:  []byte(`{"Ethernet2":{"Neighbor":"DeviceB","NeighborPort":"Ethernet11","NeighborLoopback":"10.0.0.2","NeighborMgmt":"192.168.0.2","NeighborType":"Spine"}}`),
 			valTest:  true,
 		},
 		{
-			desc:    "alias mode invalid canonical should error",
-			envMode: "alias",
+			desc: "alias mode invalid canonical should error",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			addArg:   "Ethernet0",
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected" key:{ key:"SONIC_CLI_IFACE_MODE" value:"alias" } >
+              elem: <name:"Ethernet0">
+            `,
 			wantCode: codes.InvalidArgument,
 			valTest:  false,
 		},
 		{
-			desc:    "alias mode invalid alias",
-			envMode: "alias",
+			desc: "alias mode invalid alias",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, fullDataFile)
 			},
-			addArg:   "etp9",
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected" key:{ key:"SONIC_CLI_IFACE_MODE" value:"alias" } >
+              elem: <name:"etp9">
+            `,
 			wantCode: codes.InvalidArgument,
 			valTest:  false,
 		},
 		{
-			desc:    "missing metadata fields -> None defaults",
-			envMode: "alias",
+			desc: "missing metadata fields -> None defaults",
 			init: func() {
 				AddDataSet(t, ConfigDbNum, minDataFile)
 			},
+			pathTarget: "SHOW",
+			textPbPath: `
+              elem: <name:"interfaces">
+              elem: <name:"neighbor">
+              elem: <name:"expected" key:{ key:"SONIC_CLI_IFACE_MODE" value:"alias" } >
+            `,
 			wantCode: codes.OK,
 			wantVal:  []byte(`{}`),
 			valTest:  true,
@@ -157,22 +179,12 @@ func TestShowInterfaceNeighborExpected(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			ResetDataSetsAndMappings(t)
-			if tc.envMode != "" {
-				t.Setenv(show_client.SonicCliIfaceMode, tc.envMode)
-			} else {
-				t.Setenv(show_client.SonicCliIfaceMode, "")
-			}
 			if tc.init != nil {
 				tc.init()
 			}
-
-			// Build path (append interface arg element if needed)
-			path := basePath
-			if tc.addArg != "" {
-				path += fmt.Sprintf(`elem: <name:"%s">`, tc.addArg)
-			}
-
-			runTestGet(t, ctx, gClient, "SHOW", path, tc.wantCode, tc.wantVal, tc.valTest)
+			ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+			defer cancel()
+			runTestGet(t, ctx, gClient, tc.pathTarget, tc.textPbPath, tc.wantCode, tc.wantVal, tc.valTest)
 		})
 	}
 }

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -1307,9 +1307,9 @@ func getInterfaceFlap(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 // 5) "type"
 // 6) "BackEndLeafRouter"
 func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	// TODO: Supports an interfacename as arg
+	intf := args.At(0)
 	namingMode, _ := options[SonicCliIfaceMode].String()
-	// Fetch DEVICE_NEIGHBOR
+
 	neighborTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "DEVICE_NEIGHBOR"}})
 	if err != nil {
 		log.Errorf("Failed to get DEVICE_NEIGHBOR: %v", err)
@@ -1321,13 +1321,12 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 		return nil, err
 	}
 
-	// Skip neighbor if its metadata (DEVICE_NEIGHBOR_METADATA) is missing (python try/except KeyError: pass)
 	buildEntry := func(canonIf string) (map[string]string, bool) {
 		device := GetFieldValueString(neighborTbl, canonIf, "", "name")
 		if device == "" {
 			return nil, false
 		}
-		// Require metadata key to exist (strict parity with python pass on KeyError)
+		// Require metadata key to exist (python try/except KeyError: pass)
 		if _, ok := metaTbl[device]; !ok {
 			return nil, false
 		}
@@ -1349,9 +1348,7 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 			ntype = "None"
 		}
 
-		displayIf := GetInterfaceNameForDisplay(localIf, namingMode)
-
-		out[displayIf] = map[string]string{
+		return map[string]string{
 			"Neighbor":         device,
 			"NeighborPort":     remotePort,
 			"NeighborLoopback": loopback,
@@ -1360,7 +1357,6 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 		}, true
 	}
 
-	aliasMode := GetInterfaceNamingMode() == "alias"
 	canonicalKeys := make([]string, 0, len(neighborTbl))
 	for k := range neighborTbl {
 		canonicalKeys = append(canonicalKeys, k)
@@ -1371,8 +1367,8 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 	for _, c := range canonicalKeys {
 		if entry, ok := buildEntry(c); ok {
 			key := c
-			if aliasMode {
-				key = GetInterfaceNameForDisplay(c)
+			if namingMode == "alias" {
+				key = GetInterfaceNameForDisplay(c, namingMode)
 			}
 			finalMap[key] = entry
 		}

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -1321,11 +1321,17 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 		return nil, err
 	}
 
+	// Skip neighbor if its metadata (DEVICE_NEIGHBOR_METADATA) is missing (python try/except KeyError: pass)
 	buildEntry := func(canonIf string) (map[string]string, bool) {
 		device := GetFieldValueString(neighborTbl, canonIf, "", "name")
 		if device == "" {
 			return nil, false
 		}
+		// Require metadata key to exist (strict parity with python pass on KeyError)
+		if _, ok := metaTbl[device]; !ok {
+			return nil, false
+		}
+
 		remotePort := GetFieldValueString(neighborTbl, canonIf, "None", "port")
 		if remotePort == "" {
 			remotePort = "None"
@@ -1355,27 +1361,23 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 	}
 
 	aliasMode := GetInterfaceNamingMode() == "alias"
-
-	// Collect and sort canonical keys
 	canonicalKeys := make([]string, 0, len(neighborTbl))
 	for k := range neighborTbl {
 		canonicalKeys = append(canonicalKeys, k)
 	}
 	canonicalKeys = natsortInterfaces(canonicalKeys)
 
-	// Build final map directly (alias or canonical keys depending on mode)
 	finalMap := make(map[string]map[string]string, len(canonicalKeys))
 	for _, c := range canonicalKeys {
 		if entry, ok := buildEntry(c); ok {
 			key := c
 			if aliasMode {
-				key = GetInterfaceNameForDisplay(c) // alias
+				key = GetInterfaceNameForDisplay(c)
 			}
 			finalMap[key] = entry
 		}
 	}
 
-	// Filter single interface
 	if intf != "" {
 		entry, ok := finalMap[intf]
 		if !ok {

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -1315,25 +1315,21 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 		log.Errorf("Failed to get DEVICE_NEIGHBOR: %v", err)
 		return nil, err
 	}
-
-	// Fetch DEVICE_NEIGHBOR_METADATA
 	metaTbl, err := GetMapFromQueries([][]string{{"CONFIG_DB", "DEVICE_NEIGHBOR_METADATA"}})
 	if err != nil {
 		log.Errorf("Failed to get DEVICE_NEIGHBOR_METADATA: %v", err)
 		return nil, err
 	}
 
-	out := make(map[string]map[string]string)
-	for localIf := range neighborTbl {
-		device := GetFieldValueString(neighborTbl, localIf, "", "name")
+	buildEntry := func(canonIf string) (map[string]string, bool) {
+		device := GetFieldValueString(neighborTbl, canonIf, "", "name")
 		if device == "" {
-			continue
+			return nil, false
 		}
-		remotePort := GetFieldValueString(neighborTbl, localIf, "None", "port")
+		remotePort := GetFieldValueString(neighborTbl, canonIf, "None", "port")
 		if remotePort == "" {
 			remotePort = "None"
 		}
-
 		loopback := GetFieldValueString(metaTbl, device, "None", "lo_addr")
 		if loopback == "" {
 			loopback = "None"
@@ -1355,10 +1351,40 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 			"NeighborLoopback": loopback,
 			"NeighborMgmt":     mgmt,
 			"NeighborType":     ntype,
+		}, true
+	}
+
+	aliasMode := GetInterfaceNamingMode() == "alias"
+
+	// Collect and sort canonical keys
+	canonicalKeys := make([]string, 0, len(neighborTbl))
+	for k := range neighborTbl {
+		canonicalKeys = append(canonicalKeys, k)
+	}
+	canonicalKeys = natsortInterfaces(canonicalKeys)
+
+	// Build final map directly (alias or canonical keys depending on mode)
+	finalMap := make(map[string]map[string]string, len(canonicalKeys))
+	for _, c := range canonicalKeys {
+		if entry, ok := buildEntry(c); ok {
+			key := c
+			if aliasMode {
+				key = GetInterfaceNameForDisplay(c) // alias
+			}
+			finalMap[key] = entry
 		}
 	}
 
-	return json.Marshal(out)
+	// Filter single interface
+	if intf != "" {
+		entry, ok := finalMap[intf]
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "Invalid interface name %s", intf)
+		}
+		return json.Marshal(map[string]map[string]string{intf: entry})
+	}
+
+	return json.Marshal(finalMap)
 }
 
 func getInterfaceNamingMode(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -1361,7 +1361,7 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 	for k := range neighborTbl {
 		canonicalKeys = append(canonicalKeys, k)
 	}
-	canonicalKeys = natsortInterfaces(canonicalKeys)
+	canonicalKeys = NatsortInterfaces(canonicalKeys)
 
 	finalMap := make(map[string]map[string]string, len(canonicalKeys))
 	for _, c := range canonicalKeys {

--- a/testdata/DEVICE_NEIGHBOR_EXPECTED.txt
+++ b/testdata/DEVICE_NEIGHBOR_EXPECTED.txt
@@ -1,6 +1,0 @@
-{
-  "DEVICE_NEIGHBOR|Ethernet2": {
-    "name": "DEVICE01T1",
-    "port": "Ethernet1"
-  }
-}

--- a/testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt
+++ b/testdata/DEVICE_NEIGHBOR_EXPECTED_NO_META.txt
@@ -1,6 +1,0 @@
-{
-  "DEVICE_NEIGHBOR|Ethernet4": {
-    "name": "DEVICE02T1",
-    "port": "Ethernet9"
-  }
-}

--- a/testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt
+++ b/testdata/DEVICE_NEIGHBOR_METADATA_EXPECTED.txt
@@ -1,7 +1,0 @@
-{
-  "DEVICE_NEIGHBOR_METADATA|DEVICE01T1": {
-    "lo_addr": "10.1.1.1",
-    "mgmt_addr": "192.0.2.10",
-    "type": "BackEndLeafRouter"
-  }
-}

--- a/testdata/NEIGHBOR_EXPECTED_FULL.txt
+++ b/testdata/NEIGHBOR_EXPECTED_FULL.txt
@@ -1,0 +1,26 @@
+{
+  "DEVICE_NEIGHBOR|Ethernet0": {
+    "name": "DeviceA",
+    "port": "Ethernet10"
+  },
+  "DEVICE_NEIGHBOR|Ethernet2": {
+    "name": "DeviceB",
+    "port": "Ethernet11"
+  },
+  "DEVICE_NEIGHBOR_METADATA|DeviceA": {
+    "lo_addr": "10.0.0.1",
+    "mgmt_addr": "192.168.0.1",
+    "type": "Leaf"
+  },
+  "DEVICE_NEIGHBOR_METADATA|DeviceB": {
+    "lo_addr": "10.0.0.2",
+    "mgmt_addr": "192.168.0.2",
+    "type": "Spine"
+  },
+  "PORT|Ethernet0": {
+    "alias": "etp1"
+  },
+  "PORT|Ethernet2": {
+    "alias": "etp2"
+  }
+}

--- a/testdata/NEIGHBOR_EXPECTED_MIN.txt
+++ b/testdata/NEIGHBOR_EXPECTED_MIN.txt
@@ -1,0 +1,9 @@
+{
+  "DEVICE_NEIGHBOR|Ethernet4": {
+    "name": "DeviceC",
+    "port": "Ethernet12"
+  },
+  "PORT|Ethernet4": {
+    "alias": "etp3"
+  }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Supports an interfacename as arg for "show interface neighbor expected"

#### How I did it
Add interfacename as arg 

####  What sources are you using to fetch data?
- CONFIG_DB table DEVICE_NEIGHBOR: keyed by interface (e.g. DEVICE_NEIGHBOR|Ethernet2) providing fields name (device) and port (remote port).

- CONFIG_DB table DEVICE_NEIGHBOR_METADATA: keyed by device name (e.g. DEVICE_NEIGHBOR_METADATA|DEVICE01T1) providing lo_addr, mgmt_addr, type.

#### How to verify it 
<img width="977" height="610" alt="image" src="https://github.com/user-attachments/assets/0c3413c8-8cae-45b3-8afe-2157cbfaa902" />


#### Output of show CLI that is equivalent to API output
For the default mode:
```
:~$ show interfaces neighbor expected 
LocalPort    Neighbor     NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  -----------  --------------  ------------------  --------------  -----------------
Ethernet64   ARISTA01T1   Ethernet1       None                172.16.181.10   BackEndLeafRouter
Ethernet72   ARISTA09T1   Ethernet1       None                172.16.181.11   BackEndLeafRouter
Ethernet80   ARISTA17T1   Ethernet1       None                172.16.181.12   BackEndLeafRouter
Ethernet88   ARISTA25T1   Ethernet1       None                172.16.181.13   BackEndLeafRouter
...

:~$ show interfaces neighbor expected Ethernet64
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  -----------------
Ethernet64   ARISTA01T1  Ethernet1       None                172.16.181.10   BackEndLeafRouter
```

For the alias mode:
```
:~$ show interfaces neighbor expected 
LocalPort    Neighbor     NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  -----------  --------------  ------------------  --------------  -----------------
etp9a        ARISTA01T1   Ethernet1       None                172.16.181.10   BackEndLeafRouter
etp10a       ARISTA09T1   Ethernet1       None                172.16.181.11   BackEndLeafRouter
etp11a       ARISTA17T1   Ethernet1       None                172.16.181.12   BackEndLeafRouter
etp12a       ARISTA25T1   Ethernet1       None                172.16.181.13   BackEndLeafRouter

:~$ show interfaces neighbor expected etp9a
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  -----------------
etp9a        ARISTA01T1  Ethernet1       None                172.16.181.10   BackEndLeafRouter
```

#### Manual test output of API on device 
For the default mode:
```text
root@sonic:/# gnmi_get -xpath_target SHOW -xpath interfaces/neighbor/expected -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interfaces"
  >
  elem: <
    name: "neighbor"
  >
  elem: <
    name: "expected"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757569192462511777
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interfaces"
      >
      elem: <
        name: "neighbor"
      >
      elem: <
        name: "expected"
      >
    >
    val: <
      json_ietf_val: "{
      \"Ethernet64\":{\"Neighbor\":\"ARISTA01T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.10\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\},
      \"Ethernet72\":{\"Neighbor\":\"ARISTA09T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.11\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\},
      \"Ethernet80\":{\"Neighbor\":\"ARISTA17T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.12\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\},
      \"Ethernet88\":{\"Neighbor\":\"ARISTA25T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.13\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"}
      ...
      }"
    >
  >
>


root@sonic:/# gnmi_get -xpath_target SHOW -xpath interfaces/neighbor/expected/Ethernet64 -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interfaces"
  >
  elem: <
    name: "neighbor"
  >
  elem: <
    name: "expected"
  >
  elem: <
    name: "Ethernet64"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757569442496211647
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interfaces"
      >
      elem: <
        name: "neighbor"
      >
      elem: <
        name: "expected"
      >
      elem: <
        name: "Ethernet64"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet64\":{\"Neighbor\":\"ARISTA01T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.10\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"}}"
    >
  >
>
```

For the alias mode:
```text
root@sonic:/# gnmi_get -xpath_target SHOW -xpath interfaces/neighbor/expected[SONIC_CLI_IFACE_MODE=alias] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interfaces"
  >
  elem: <
    name: "neighbor"
  >
  elem: <
    name: "expected"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757568283375126486
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interfaces"
      >
      elem: <
        name: "neighbor"
      >
      elem: <
        name: "expected"
      >
    >
    val: <
      json_ietf_val: "{\"etp9a\":{\"Neighbor\":\"ARISTA01T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.10\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"},
        \"etp10a\":{\"Neighbor\":\"ARISTA09T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.11\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"},
        \"etp11a\":{\"Neighbor\":\"ARISTA17T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.12\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"},
        \"etp12a\":{\"Neighbor\":\"ARISTA25T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.13\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"}
        ...
      }"
    >
  >
>

root@sonic:/# gnmi_get -xpath_target SHOW -xpath interfaces/neighbor/expected/etp10a[SONIC_CLI_IFACE_MODE=alias] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interfaces"
  >
  elem: <
    name: "neighbor"
  >
  elem: <
    name: "expected"
  >
  elem: <
    name: "etp10a"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757568301531674127
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interfaces"
      >
      elem: <
        name: "neighbor"
      >
      elem: <
        name: "expected"
      >
      elem: <
        name: "etp10a"
      >
    >
    val: <
      json_ietf_val: "{\"etp10a\":{\"Neighbor\":\"ARISTA09T1\",\"NeighborLoopback\":\"None\",\"NeighborMgmt\":\"172.16.181.11\",\"NeighborPort\":\"Ethernet1\",\"NeighborType\":\"BackEndLeafRouter\"}}"
    >
  >
>

```
