### PR TITLE
Remove non-common functions from show_common.go

### DIFF
--- a/show_client/dropstat_cli.go
+++ b/show_client/dropstat_cli.go
@@ -112,7 +112,7 @@ func showPortDropCounts(group string, counterType string) map[string]map[string]
 		row["State"] = state
 
 		for _, ctr := range counters {
-			diff := getOrDefault(countsTable[port], ctr, int64(0)) - getOrDefault(getOrDefault(portDropCkpt, port, map[string]int64{}), ctr, int64(0))
+			diff := GetOrDefault(countsTable[port], ctr, int64(0)) - GetOrDefault(GetOrDefault(portDropCkpt, port, map[string]int64{}), ctr, int64(0))
 			alias, ok := headmap[ctr]
 			if !ok || alias == "" {
 				alias = ctr
@@ -318,7 +318,7 @@ func getAlias(counterName string) string {
 		return counterName
 	}
 
-	aliasVal := fmt.Sprint(getOrDefault(aliasQuery, "alias", interface{}(counterName)))
+	aliasVal := fmt.Sprint(GetOrDefault(aliasQuery, "alias", interface{}(counterName)))
 	return aliasVal
 }
 
@@ -340,7 +340,7 @@ func inGroup(counterStat string, objectStatMap string, group string) bool {
 		return false
 	}
 
-	return group == fmt.Sprint(getOrDefault(group_query, "group", ""))
+	return group == fmt.Sprint(GetOrDefault(group_query, "group", ""))
 }
 
 // Checks whether the type of the given counter_stat is the same as counter_type.
@@ -362,7 +362,7 @@ func isType(counterStat string, objectStatMap string, counterType string) bool {
 		return false
 	}
 
-	return counterType == fmt.Sprint(getOrDefault(typeQuery, "type", ""))
+	return counterType == fmt.Sprint(GetOrDefault(typeQuery, "type", ""))
 }
 
 // getEntry returns the CONFIG_DB DEBUG_COUNTER row for a given counterName.

--- a/show_client/fib_common.go
+++ b/show_client/fib_common.go
@@ -1,6 +1,7 @@
 package show_client
 
 import (
+	"net"
 	"sort"
 	"strings"
 
@@ -74,4 +75,18 @@ func parseFibVrf(key string) (string, string) {
 		}
 	}
 	return "", key
+}
+
+// matchIPFamily checks if prefix belongs to desired family
+func matchIPFamily(prefix string, wantIPv6 bool) bool {
+	host := prefix
+	if i := strings.IndexByte(prefix, '/'); i >= 0 {
+		host = prefix[:i]
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	isV6 := ip.To4() == nil
+	return isV6 == wantIPv6
 }

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -2,7 +2,6 @@ package show_client
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"sort"
@@ -289,22 +288,7 @@ func GetSumFields(data map[string]interface{}, key string, defaultValue string, 
 	return strconv.FormatInt(total, base10)
 }
 
-func calculateDiffCounters(oldCounter string, newCounter string, defaultValue string) string {
-	if oldCounter == defaultValue || newCounter == defaultValue {
-		return defaultValue
-	}
-	oldCounterValue, err := strconv.ParseInt(oldCounter, base10, 64)
-	if err != nil {
-		return defaultValue
-	}
-	newCounterValue, err := strconv.ParseInt(newCounter, base10, 64)
-	if err != nil {
-		return defaultValue
-	}
-	return strconv.FormatInt(newCounterValue-oldCounterValue, base10)
-}
-
-func natsortInterfaces(interfaces []string) []string {
+func NatsortInterfaces(interfaces []string) []string {
 	// Naturally sort the port list
 	sort.Sort(natural.StringSlice(interfaces))
 	return interfaces
@@ -393,27 +377,13 @@ func SplitCompositeKey(k string) (string, string, bool) {
 	return "", "", false
 }
 
-// getOrDefault returns m[key] when present; otherwise returns def.
+// GetOrDefault returns m[key] when present; otherwise returns def.
 // Safe to call with a nil map. Handy for nested map lookups with explicit defaults.
-func getOrDefault[T any](m map[string]T, key string, def T) T {
+func GetOrDefault[T any](m map[string]T, key string, def T) T {
 	if v, ok := m[key]; ok {
 		return v
 	}
 	return def
-}
-
-// matchIPFamily checks if prefix belongs to desired family
-func matchIPFamily(prefix string, wantIPv6 bool) bool {
-	host := prefix
-	if i := strings.IndexByte(prefix, '/'); i >= 0 {
-		host = prefix[:i]
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false
-	}
-	isV6 := ip.To4() == nil
-	return isV6 == wantIPv6
 }
 
 // ContainsString returns true if target is present in list.

--- a/show_client/srv6_cli.go
+++ b/show_client/srv6_cli.go
@@ -40,7 +40,7 @@ func getSRv6Stats(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 		sids = append(sids, fmt.Sprintf("%s", k))
 	}
 	// Natsort the slice
-	sids = natsortInterfaces(sids)
+	sids = NatsortInterfaces(sids)
 
 	sidCounters := make([]map[string]string, 0, len(sids))
 	for _, sid := range sids {

--- a/show_client/vlan_cli.go
+++ b/show_client/vlan_cli.go
@@ -96,7 +96,7 @@ func getVlanDhcpHelperAddress(cfg vlanConfig, vlan string) interface{} {
 			}
 		}
 	}
-	ipAddress = natsortInterfaces(ipAddress)
+	ipAddress = NatsortInterfaces(ipAddress)
 	return ipAddress
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We're going to move show_common.go into a shared subpackage `common`. The planned steps are:
1. Move non-common functions from show_common.go
2. Capitalize all common helper function names
3. Move show_common.go into `common` subpackage and fix all references.

In this PR, we're doing step 1 & 2.

#### How I did it
* Capitalize common helper functions
  * GetOrDefault
  * NatsortInterfaces
* Move matchIPFamily into fib_common.go
* Move calculateDiffCounters into interface_cli.go

#### (SHOW command specific) What sources are you using to fetch data?
N/A

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
UT

#### (Show command specific) Output of show CLI that is equivalent to API output
N/A

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A