### PR TITLE
Move GetInterfaceSwitchportMode out of show_common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ $(ENVFILE):
 check_gotest: $(DBCONFG) $(ENVFILE)
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-telemetry.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/telemetry
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 20m -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 30m -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
 ifneq ($(ENABLE_DIALOUT_VALUE),0)
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -coverprofile=coverage-dialout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
 endif

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -1196,6 +1196,26 @@ func getInterfaceSwitchportStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 	return json.Marshal(switchportStatus)
 }
 
+// GetInterfaceSwitchportMode returns the switchport mode.
+func GetInterfaceSwitchportMode(
+	portTbl, portChannelTbl, vlanMemberTbl map[string]interface{},
+	name string,
+) string {
+	if m := GetFieldValueString(portTbl, name, "", "mode"); m != "" {
+		return m
+	}
+	if m := GetFieldValueString(portChannelTbl, name, "", "mode"); m != "" {
+		return m
+	}
+	for k := range vlanMemberTbl {
+		_, member, ok := SplitCompositeKey(k)
+		if ok && member == name {
+			return "trunk"
+		}
+	}
+	return "routed"
+}
+
 // IsInterfaceInPortchannel reports whether interfaceName is a member of any portchannel.
 func IsInterfaceInPortchannel(portchannelMemberTable map[string]interface{}, interfaceName string) bool {
 	if portchannelMemberTable == nil || interfaceName == "" {

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -341,26 +341,6 @@ func GetInterfaceNameForDisplay(name string, namingMode string) string {
 	return name
 }
 
-// GetInterfaceSwitchportMode returns the switchport mode.
-func GetInterfaceSwitchportMode(
-	portTbl, portChannelTbl, vlanMemberTbl map[string]interface{},
-	name string,
-) string {
-	if m := GetFieldValueString(portTbl, name, "", "mode"); m != "" {
-		return m
-	}
-	if m := GetFieldValueString(portChannelTbl, name, "", "mode"); m != "" {
-		return m
-	}
-	for k := range vlanMemberTbl {
-		_, member, ok := SplitCompositeKey(k)
-		if ok && member == name {
-			return "trunk"
-		}
-	}
-	return "routed"
-}
-
 // SplitCompositeKey splits a two-part composite key using '|' or ':' delimiters.
 // Returns left, right, true on success; empty strings and false otherwise.
 // Examples:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `GetInterfaceSwitchportMode` function is specific to command `show interfaces switchport status`.

#### How I did it
Move `GetInterfaceSwitchportMode` function from show_common.go to interface_cli.go

#### (SHOW command specific) What sources are you using to fetch data?
N/A

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
N/A

#### (Show command specific) Output of show CLI that is equivalent to API output
N/A

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A