### PR TITLE
Migrate to use argument for  command

### DIFF
--- a/gnmi_server/ipv6_route_cli_test.go
+++ b/gnmi_server/ipv6_route_cli_test.go
@@ -49,7 +49,7 @@ func TestGetIPv6Route(t *testing.T) {
 		valTest        bool
 	}{
 		{
-			desc:       "query SHOW ipv6 route base",
+			desc:       "query `SHOW ipv6 route`",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "ipv6" >
@@ -61,11 +61,12 @@ func TestGetIPv6Route(t *testing.T) {
 			valTest:        true,
 		},
 		{
-			desc:       "query SHOW ipv6 route bgp",
+			desc:       "query `SHOW ipv6 route bgp`",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "ipv6" >
-				elem: <name: "route" key <key: "args" value: "bgp" > >
+				elem: <name: "route" >
+				elem: <name: "bgp" >
 			`,
 			wantRetCode:    codes.OK,
 			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
@@ -73,11 +74,12 @@ func TestGetIPv6Route(t *testing.T) {
 			valTest:        true,
 		},
 		{
-			desc:       "query SHOW ipv6 route prefix arg",
+			desc:       "query `SHOW ipv6 route [IPADDRESS]`",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "ipv6" >
-				elem: <name: "route" key <key: "args" value: "2001:db8::/64" > >
+				elem: <name: "route" >
+				elem: <name: "2001:db8::/64" >
 			`,
 			wantRetCode:    codes.OK,
 			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_PREFIX.json",
@@ -85,15 +87,29 @@ func TestGetIPv6Route(t *testing.T) {
 			valTest:        true,
 		},
 		{
-			desc:       "query SHOW ipv6 route args include json (no duplicate)",
+			desc:       "query `SHOW ipv6 route bgp json`",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "ipv6" >
-				elem: <name: "route" key <key: "args" value: "bgp json" > >
+				elem: <name: "route" >
+				elem: <name: "bgp" >
 			`,
 			wantRetCode:    codes.OK,
 			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
 			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE_BGP.json",
+			valTest:        true,
+		},
+		{
+			desc:       "query `SHOW ipv6 route nexthop-group`",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "ipv6" >
+				elem: <name: "route" >
+				elem: <name: "nexthop-group" >
+			`,
+			wantRetCode:    codes.OK,
+			wantRespFile:   "../testdata/VTYSH_SHOW_IPV6_ROUTE.json",
+			mockOutputFile: "../testdata/VTYSH_SHOW_IPV6_ROUTE.json",
 			valTest:        true,
 		},
 		{

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -26,7 +26,6 @@ const (
 	showCmdOptionIPAddressDesc         = "[ipaddress=TEXT] Filter by single IP address"
 	showCmdOptionIPV6AddressDesc       = "[ipaddress=TEXT] Filter by IPv6 address"
 	showCmdOptionInfoTypeDesc          = "[info_type=TEXT] Filter by information type"
-	showCmdOptionFrrRouteArgsDesc      = "[args=TEXT] Filter by FRR route arguments"
 	showCmdOptionSonicCliIfaceModeDesc = "[SONIC_CLI_IFACE_MODE=TEXT] Filter by sonic interface naming mode (eg alias/default)"
 )
 
@@ -176,12 +175,6 @@ var (
 	showCmdOptionInfoTypeForBgpNetwork = sdc.NewShowCmdOption(
 		"info_type",
 		showCmdOptionInfoTypeDesc,
-		sdc.StringValue,
-	)
-
-	showCmdOptionFrrRouteArgs = sdc.NewShowCmdOption(
-		"args",
-		showCmdOptionFrrRouteArgsDesc,
 		sdc.StringValue,
 	)
 

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -333,7 +333,6 @@ func init() {
 		nil,
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 		showCmdOptionDisplay,
-		showCmdOptionFrrRouteArgs,
 	)
 
 	// SHOW/lldp


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Using argument instead of option for VTYSH arguments

#### How I did it
* Remove frr "args" option and use argument in gNMI

#### (SHOW command specific) What sources are you using to fetch data?

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
<img width="914" height="550" alt="image" src="https://github.com/user-attachments/assets/b5896486-a36c-4333-bb16-47a75cb00a8c" />

#### (Show command specific) Output of show CLI that is equivalent to API output

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
* protocol as argument
```shell
gnmi_get -xpath_target SHOW -xpath ipv6/route/kernel -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "ipv6"
  >
  elem: <
    name: "route"
  >
  elem: <
    name: "kernel"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757985459472245716
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "ipv6"
      >
      elem: <
        name: "route"
      >
      elem: <
        name: "kernel"
      >
    >
    val: <
      json_ietf_val: "{\"fc00:1::32/128\":[{\"distance\":0,\"installed\":true,\"internalFlags\":0,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":256,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"prefix\":\"fc00:1::32/128\",\"prefixLen\":128,\"protocol\":\"kernel\",\"table\":254,\"uptime\":\"02w6d03h\",\"vrfId\":0,\"vrfName\":\"default\"}]}"
    >
  >
>
```
* IPAddress as argument:
```shell
root@str5-7060x6-moby-512-4:/# gnmi_get -xpath_target SHOW -xpath ipv6/route/fc00:1::32 -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "ipv6"
  >
  elem: <
    name: "route"
  >
  elem: <
    name: "fc00:1::32"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757985480522500658
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "ipv6"
      >
      elem: <
        name: "route"
      >
      elem: <
        name: "fc00:1::32"
      >
    >
    val: <
      json_ietf_val: "{\"fc00:1::32/128\":[{\"destSelected\":true,\"distance\":0,\"installed\":true,\"installedNexthopGroupId\":11,\"internalFlags\":264,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":0,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"offloaded\":true,\"prefix\":\"fc00:1::32/128\",\"prefixLen\":128,\"protocol\":\"connected\",\"selected\":true,\"table\":254,\"uptime\":\"02w6d03h\",\"vrfId\":0,\"vrfName\":\"default\"},{\"distance\":0,\"installed\":true,\"internalFlags\":0,\"internalNextHopActiveNum\":1,\"internalNextHopNum\":1,\"internalStatus\":16,\"metric\":256,\"nexthopGroupId\":11,\"nexthops\":[{\"active\":true,\"directlyConnected\":true,\"fib\":true,\"flags\":3,\"interfaceIndex\":5,\"interfaceName\":\"Loopback0\",\"weight\":1}],\"prefix\":\"fc00:1::32/128\",\"prefixLen\":128,\"protocol\":\"kernel\",\"table\":254,\"uptime\":\"02w6d03h\",\"vrfId\":0,\"vrfName\":\"default\"}]}"
    >
  >
>
```
* Test IP address escaping
```shell
root@1af9c31fed9a:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t 10.64.247.135 -p 50051 -m get -x "ipv6/route/2a01:111:e210:b000::\/64" -xt SHOW -o ndastreamingservertest
/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if filter_event_regex is not "":
/root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(match) is not 0:
Performing GetRequest, encoding=JSON_IETF to 10.64.247.135  with the following gNMI Path
 -------------------------
 [elem {
  name: "ipv6"
}
elem {
  name: "route"
}
elem {
  name: "2a01:111:e210:b000::/64"
}
]
The GetResponse is below
-------------------------

{
  "2a01:111:e210:b000::/64": [
    {
      "destSelected": true,
      "distance": 0,
      "installed": true,
      "installedNexthopGroupId": 2789710,
      "internalFlags": 264,
      "internalNextHopActiveNum": 1,
      "internalNextHopNum": 1,
      "internalStatus": 16,
      "metric": 0,
      "nexthopGroupId": 2789710,
      "nexthops": [
        {
          "active": true,
          "directlyConnected": true,
          "fib": true,
          "flags": 3,
          "interfaceIndex": 2,
          "interfaceName": "eth0"
        }
      ],
      "offloaded": true,
      "prefix": "2a01:111:e210:b000::/64",
      "prefixLen": 64,
      "protocol": "connected",
      "selected": true,
      "table": 254,
      "uptime": "02:46:48",
      "vrfId": 0,
      "vrfName": "default"
    }
  ]
}
-------------------------
```
#### A picture of a cute animal (not mandatory but encouraged)
