### PR TITLE
Add support for interface argumet of show lldp neighobors

### DIFF
--- a/gnmi_server/lldp_neighbors_cli_test.go
+++ b/gnmi_server/lldp_neighbors_cli_test.go
@@ -56,6 +56,13 @@ func TestGetLLDPNeighbors(t *testing.T) {
 		t.Fatalf("Failed to read file %v err: %v", expectedLLDPNeighborsResponseFileName, err)
 	}
 
+	// Expected output for normal device with specified interface name
+	expectedLLDPNeighborsWithIfNameResponseFileName := "../testdata/lldp/Expected_show_lldp_neighbors_filtered_response.txt"
+	expectedLLDPNeighborsWithIfNameResponse, err := ioutil.ReadFile(expectedLLDPNeighborsWithIfNameResponseFileName)
+	if err != nil {
+		t.Fatalf("Failed to read file %v err: %v", expectedLLDPNeighborsWithIfNameResponseFileName, err)
+	}
+
 	tests := []struct {
 		desc           string
 		pathTarget     string
@@ -104,6 +111,38 @@ func TestGetLLDPNeighbors(t *testing.T) {
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(expectedLLDPNeighborsResponse),
+			valTest:     true,
+			mockOutputFile: map[string]string{
+				"docker": "../testdata/lldp/lldpctl_json.txt",
+			},
+			ignoreValOrder: true,
+		},
+		{
+			desc:       "query SHOW lldp neighbors - normal device with specified interface name",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "lldp" >
+				elem: <name: "neighbors" >
+				elem: <name: "Ethernet354" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedLLDPNeighborsWithIfNameResponse),
+			valTest:     true,
+			mockOutputFile: map[string]string{
+				"docker": "../testdata/lldp/lldpctl_json.txt",
+			},
+			ignoreValOrder: true,
+		},
+		{
+			desc:       "query SHOW lldp neighbors - normal device with non-existing interface name",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "lldp" >
+				elem: <name: "neighbors" >
+				elem: <name: "nonexist0" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedEmptyDBResponse),
 			valTest:     true,
 			mockOutputFile: map[string]string{
 				"docker": "../testdata/lldp/lldpctl_json.txt",

--- a/show_client/lldp_neighbors_cli.go
+++ b/show_client/lldp_neighbors_cli.go
@@ -253,7 +253,9 @@ func extractNeighborsEntry(iface interfaceEntry) lldpNeighborsEntry {
 }
 
 func getLLDPNeighbors(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	// TODO: Needs to use argument
+	// Get interface name from args, if provided, default to ""
+	ifaceName := args.At(0)
+
 	data, err := getLLDPDataFromHostCommand()
 	if err != nil {
 		log.Errorf("Failed to get lldp data, get err %v", err)
@@ -262,6 +264,18 @@ func getLLDPNeighbors(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 
 	// parse neighbors summary from full lldp data
 	neighbors := extractAllNeighborsEntry(data)
+
+	// If interface name is provided, filter to return only that interface
+	if ifaceName != "" {
+		if entry, ok := neighbors[ifaceName]; ok {
+			singleNeighbor := make(map[string]lldpNeighborsEntry)
+			singleNeighbor[ifaceName] = entry
+			neighbors = singleNeighbor
+		} else {
+			// Interface name provided but not found; return empty map
+			neighbors = make(map[string]lldpNeighborsEntry)
+		}
+	}
 
 	// create response structure
 	var response = lldpNeighborsResponse{

--- a/testdata/lldp/Expected_show_lldp_neighbors_filtered_response.txt
+++ b/testdata/lldp/Expected_show_lldp_neighbors_filtered_response.txt
@@ -1,0 +1,39 @@
+{
+	"title": "LLDP neighbors",
+	"interfaces": {
+		"Ethernet354": {
+			"via": "LLDP",
+			"RID": "2",
+			"Time": "15 days, 03:12:34",
+			"Chassis": {
+				"ChassisID": "mac ff:ff:ff:ff:ff:ff",
+				"SysName": "sonic-device-6",
+				"SysDescr": "SONiC Software Version: SONiC.20250305.10 - HwSku: Arista-7060X6-64PE - Distribution: Debian 12.9 - Kernel: 6.1.0-29-2-amd64",
+				"MgmtIP": "10.10.10.10",
+				"MgmtIface": "2",
+				"Capability": [
+					"Bridge, on",
+					"Router, on",
+					"Wlan, off",
+					"Station, off"
+				]
+			},
+			"Port": {
+				"PortID": "ifname Ethernet45/3",
+				"PortDescr": "Ethernet354",
+				"TTL": "120"
+			},
+			"VLAN": [
+				{
+					"vlan-id": "101",
+					"pvid": "yes"
+				},				
+				{
+					"vlan-id": "201",
+					"pvid": "no",
+					"value": "vlan201"
+				}
+			]
+		}	
+	}
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Improve gNMI getter of 'show lldp neighbors' to support filter result by interface name

#### How I did it
Improve the func ''getLLDPNeighbors" to filter result by specified interface name.
Get interface name from args, and filter result.

#### (SHOW command specific) What sources are you using to fetch data?
Fetch JSON data via nsenter to call command 'docker exec lldp lldpctl -f json0`

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
Add two new Unit Tests:
=== RUN   **TestGetLLDPNeighbors/query_SHOW_lldp_neighbors_-_normal_device_with_specified_interface_name**
I0910 11:39:17.139587  317685 server.go:399] GetRequest paths: [elem:{name:"lldp"} elem:{name:"neighbors"} elem:{name:"Ethernet354"}]
I0910 11:39:17.139856  317685 lldp_helpers.go:106] Start to get lldp data from lldpctl
I0910 11:39:17.141195  317685 show_client.go:134] Get done, total time taken: 1 ms
=== RUN   **TestGetLLDPNeighbors/query_SHOW_lldp_neighbors_-_normal_device_with_non-existing_interface_name**
I0910 11:39:17.142521  317685 server.go:399] GetRequest paths: [elem:{name:"lldp"} elem:{name:"neighbors"} elem:{name:"nonexist0"}]
I0910 11:39:17.142650  317685 lldp_helpers.go:106] Start to get lldp data from lldpctl
I0910 11:39:17.143910  317685 show_client.go:134] Get done, total time taken: 1 ms
--- PASS: TestGetLLDPNeighbors (0.59s)
    --- PASS: TestGetLLDPNeighbors/query_SHOW_lldp_neighbors_-_normal_device_with_specified_interface_name (0.00s)
    --- PASS: TestGetLLDPNeighbors/query_SHOW_lldp_neighbors_-_normal_device_with_non-existing_interface_name (0.00s)
PASS

Test on Lab devices

<img width="685" height="443" alt="image" src="https://github.com/user-attachments/assets/c50389db-31ce-4a90-9996-9e22645f8142" />


#### (Show command specific) Output of show CLI that is equivalent to API output
<img width="510" height="134" alt="image" src="https://github.com/user-attachments/assets/f022f3be-29bf-41e5-adb7-d16daf2c9b27" />

For 'show lldp neighbors' command:
Example output of 'show lldp neighbors {interfacename}' command:

```
admin@sonic:~$ show lldp neighbors eth0
LLDP neighbors:
-------------------------------------------------------------------------------
Interface:    eth0, via: LLDP, RID: 1, Time: 10 days, 00:58:57
  Chassis:     
    ChassisID:    mac f4:b5:2f:56:37:40
    SysName:      <remote device name>
    SysDescr:     Juniper Networks, Inc. ex2200-48t-4g , version 12.3R4.6 Build date: 2013-09-13 02:53:16 UTC 
    Capability:   Bridge, on
    Capability:   Router, on
  Port:        
    PortID:       local 508
    PortDescr:    ge-0/0/11.0
    TTL:          90
    MFS:          1514
    PMD autoneg:  supported: yes, enabled: yes
      Adv:          10Base-T, HD: yes, FD: yes
      Adv:          100Base-TX, HD: yes, FD: yes
      Adv:          1000Base-T, HD: no, FD: yes
      MAU oper type: unknown
  VLAN:         147, pvid: yes labuse
  LLDP-MED:    
    Device Type:  Network Connectivity Device
    Capability:   Capabilities, yes
    Capability:   Policy, yes
    Capability:   Location, yes
    Capability:   MDI/PSE, yes
  Unknown TLVs:
    TLV:          OUI: 00,90,69, SubType: 1, Len: 12 43,55,30,32,31,33,35,31,30,36,36,33
-------------------------------------------------------------------------------

```

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

```
root@str3-t0-8102-smartswitch-02:/# gnmi_get -xpath_target SHOW -xpath **lldp/neighbors/eth0** -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "lldp"
  >
  elem: <
    name: "neighbors"
  >
  elem: <
    name: "eth0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757504661553024396
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "lldp"
      >
      elem: <
        name: "neighbors"
      >
      elem: <
        name: "eth0"
      >
    >
    val: <
      json_ietf_val: "{\"title\":\"LLDP neighbors\",\"interfaces\":{\"eth0\":{\"via\":\"LLDP\",\"RID\":\"1\",\"Time\":\"29 days, 03:24:54\",\"Chassis\":{\"ChassisID\":\"mac f4:b5:2f:56:37:40\",\"SysName\":\"str-22ex-216be05\",\"SysDescr\":\"Juniper Networks, Inc. ex2200-48t-4g , version 12.3R4.6 Build date: 2013-09-13 02:53:16 UTC \",\"Capability\":[\"Bridge, on\",\"Router, on\"]},\"Port\":{\"PortID\":\"local 508\",\"PortDescr\":\"ge-0/0/11.0\",\"TTL\":\"90\",\"MFS\":\"1514\",\"PMD-autoneg\":{\"supported\":\"yes\",\"enabled\":\"yes\",\"Adv\":[{\"Type\":\"10Base-T\",\"HD\":\"yes\",\"FD\":\"yes\"},{\"Type\":\"100Base-TX\",\"HD\":\"yes\",\"FD\":\"yes\"},{\"Type\":\"1000Base-T\",\"HD\":\"no\",\"FD\":\"yes\"}],\"MAU-oper-type\":\"unknown\"}},\"VLAN\":[{\"vlan-id\":\"147\",\"pvid\":\"yes\",\"value\":\"labuse\"}],\"LLDP-MED\":[{\"Device-type\":\"Network Connectivity Device\",\"Capability\":[\"Capabilities, yes\",\"Policy, yes\",\"Location, yes\",\"MDI/PSE, yes\"]}],\"UnknownTLVs\":[{\"unknown-tlv\":[{\"oui\":\"00,90,69\",\"subtype\":\"1\",\"len\":\"12\",\"value\":\"43,55,30,32,31,33,35,31,30,36,36,33\"}]}]}}}"
    >
  >
>

```
#### A picture of a cute animal (not mandatory but encouraged)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/551b4c64-5fb5-4dcd-9547-a47002c29c00" />
