### PR TITLE
Adding telemetry support for `show queue wredcounters`

### DIFF
--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -27,6 +27,7 @@ const (
 	showCmdOptionIPV6AddressDesc       = "[ipaddress=TEXT] Filter by IPv6 address"
 	showCmdOptionInfoTypeDesc          = "[info_type=TEXT] Filter by information type"
 	showCmdOptionSonicCliIfaceModeDesc = "[SONIC_CLI_IFACE_MODE=TEXT] Filter by sonic interface naming mode (eg alias/default)"
+	showCmdOptionAllDesc               = "[all=true] No-op since all queue counters are shown by default"
 )
 
 // Option keys
@@ -182,5 +183,17 @@ var (
 		SonicCliIfaceMode,
 		showCmdOptionSonicCliIfaceModeDesc,
 		sdc.StringValue,
+	)
+
+	showCmdOptionAll = sdc.NewShowCmdOption(
+		"all",
+		showCmdOptionAllDesc,
+		sdc.BoolValue,
+	)
+
+	showCmdOptionVoq = sdc.NewShowCmdOption(
+		"voq",
+		showCmdOptionUnimplementedDesc,
+		sdc.BoolValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -444,12 +444,30 @@ func init() {
 		0,
 		1,
 		nil,
-		showCmdOptionInterfaces, // TODO: Should be arg
+		showCmdOptionInterfaces,
 		showCmdOptionDisplay,
 		showCmdOptionNonzero,
+		showCmdOptionAll,
 		showCmdOptionTrim,
+		sdc.UnimplementedOption(showCmdOptionVoq),
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 		showCmdOptionVerbose,
+		showCmdOptionJson,
+	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "queue", "wredcounters"},
+		getQueueWredCounters,
+		"SHOW/queue/wredcounters/{INTERFACENAME}[OPTIONS]: Show queue WRED counters",
+		0,
+		1,
+		nil,
+		showCmdOptionInterfaces,
+		showCmdOptionDisplay,
+		showCmdOptionNonzero,
+		sdc.UnimplementedOption(showCmdOptionVoq),
+		sdc.UnimplementedOption(showCmdOptionNamespace),
+		showCmdOptionVerbose,
+		showCmdOptionJson,
 	)
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "queue", "watermark"},

--- a/testdata/WRED_COUNTERS_RESULTS_ALL.txt
+++ b/testdata/WRED_COUNTERS_RESULTS_ALL.txt
@@ -1,0 +1,56 @@
+{
+    "Ethernet0:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet0:1": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet0:2": {
+        "WredDrp/pkts": "2",
+        "WredDrp/bytes": "512",
+        "EcnMarked/pkts": "0",
+        "EcnMarked/bytes": "0"
+    },
+    "Ethernet40:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet40:1": {
+        "WredDrp/pkts": "5",
+        "WredDrp/bytes": "500",
+        "EcnMarked/pkts": "10",
+        "EcnMarked/bytes": "1000"
+    },
+    "Ethernet40:2": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:1": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:2": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    }
+}

--- a/testdata/WRED_COUNTERS_RESULTS_ETH0.txt
+++ b/testdata/WRED_COUNTERS_RESULTS_ETH0.txt
@@ -1,0 +1,20 @@
+{
+    "Ethernet0:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet0:1": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet0:2": {
+        "WredDrp/pkts": "2",
+        "WredDrp/bytes": "512",
+        "EcnMarked/pkts": "0",
+        "EcnMarked/bytes": "0"
+    }
+}

--- a/testdata/WRED_COUNTERS_RESULTS_ETH40_ETH80.txt
+++ b/testdata/WRED_COUNTERS_RESULTS_ETH40_ETH80.txt
@@ -1,0 +1,38 @@
+{
+    "Ethernet40:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet40:1": {
+        "WredDrp/pkts": "5",
+        "WredDrp/bytes": "500",
+        "EcnMarked/pkts": "10",
+        "EcnMarked/bytes": "1000"
+    },
+    "Ethernet40:2": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:0": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:1": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    },
+    "Ethernet80:2": {
+        "WredDrp/pkts": "N/A",
+        "WredDrp/bytes": "N/A",
+        "EcnMarked/pkts": "N/A",
+        "EcnMarked/bytes": "N/A"
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. To add the ability to query WRED queue counters using gNMI.
2. To add support for interface argument for both `show queue counters` and `show queue wredcounters`.

#### How I did it
1. Updated the existing code for `show queue counters` in `queue_cli.go` to only return WRED queue counters for `show queue wredcounters`.
2. Added support for the interface argument.
3. Added additional no-op or unimplemented options.

Supported options:
1. `interfaces`: Comma-separated list of SONiC interfaces for which WRED queue counters should be returned. If this option is not specified, it is as if all interfaces are specified.
4. `nonzero`: A Boolean option. If it is set to true, only counters that are not 0 and not "N/A" are returned. The default value for this option is `false`.
**Note**: If `nonzero` is set to `true` and there is a queue (e.g., `Ethernet0:4`) for which all WRED counters are either 0 or "N/A", then the queue appears in the JSON output like this: `"Ethernet0:4": {}`.

#### (SHOW command specific) What sources are you using to fetch data?
The following real paths (tables) are used to construct the JSON output:
1. `COUNTERS_DB/COUNTERS_QUEUE_NAME_MAP`
5. `COUNTERS_DB/COUNTERS`

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
You can run unit tests or test it on a switch.
Unit test results:
```
2025-09-13T04:14:56.6247598Z === RUN   TestGetQueueCounters
2025-09-13T04:14:59.5655148Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_NO_DATA
2025-09-13T04:14:59.5888914Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters
2025-09-13T04:14:59.5963495Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_trim_option_(trim=true)
2025-09-13T04:14:59.6022770Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(one_interface)
2025-09-13T04:14:59.6059263Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interface_arg
2025-09-13T04:14:59.6105251Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(two_interfaces)
2025-09-13T04:14:59.6156528Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_and_interface_arg
2025-09-13T04:14:59.6214638Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_and_interface_arg_with_overlap
2025-09-13T04:14:59.6272997Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_and_nonzero_options_(one_interface,_nonzero=true)
2025-09-13T04:14:59.6313498Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_and_nonzero_options_(one_interface,_nonzero=false)
2025-09-13T04:14:59.6353720Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces,_nonzero,_and_trim_options_(one_interface,_nonzero=true,_trim=true)
2025-09-13T04:14:59.6391810Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interface_arg_with_nonzero_and_trim_options_(nonzero=true,_trim=true)
2025-09-13T04:14:59.6422695Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(invalid_interface)
2025-09-13T04:14:59.6440013Z E0913 04:14:59.643520   20350 queue_cli.go:167] Unable to pull data for queries [[COUNTERS_DB COUNTERS Ethernet7 Queues]], got err query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6440891Z E0913 04:14:59.643571   20350 queue_cli.go:222] Unable to get queue counters due to err: query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6455794Z === RUN   TestGetQueueCounters/query_SHOW_queue_counters_interface_arg_(invalid_interface)
2025-09-13T04:14:59.6466574Z E0913 04:14:59.646258   20350 queue_cli.go:167] Unable to pull data for queries [[COUNTERS_DB COUNTERS Ethernet7 Queues]], got err query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6472975Z E0913 04:14:59.646306   20350 queue_cli.go:222] Unable to get queue counters due to err: query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6473889Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_NO_DATA
2025-09-13T04:14:59.6530385Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(all_interfaces)
2025-09-13T04:14:59.6588897Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface)
2025-09-13T04:14:59.6625279Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(two_interfaces)
2025-09-13T04:14:59.6684923Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_interface_arg
2025-09-13T04:14:59.6715590Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_interfaces_option_and_interface_arg
2025-09-13T04:14:59.6772449Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_interfaces_option_and_interface_arg_with_overlap
2025-09-13T04:14:59.6832634Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface,_nonzero=true)
2025-09-13T04:14:59.6867462Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_with_interface_arg_(nonzero=true)
2025-09-13T04:14:59.6903469Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface,_nonzero=false)
2025-09-13T04:14:59.6936827Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_(invalid_interface)
2025-09-13T04:14:59.6957703Z E0913 04:14:59.695354   20350 queue_cli.go:167] Unable to pull data for queries [[COUNTERS_DB COUNTERS Ethernet7 Queues]], got err query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6958984Z E0913 04:14:59.695403   20350 queue_cli.go:239] Unable to get queue WRED counters due to err: query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6975876Z === RUN   TestGetQueueCounters/query_SHOW_queue_wredcounters_with_interface_arg_(invalid_interface)
2025-09-13T04:14:59.6991196Z E0913 04:14:59.698568   20350 queue_cli.go:167] Unable to pull data for queries [[COUNTERS_DB COUNTERS Ethernet7 Queues]], got err query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.6991877Z E0913 04:14:59.698609   20350 queue_cli.go:239] Unable to get queue WRED counters due to err: query [COUNTERS_DB COUNTERS Ethernet7 Queues] failed: No valid entry found on COUNTERS:Ethernet7:Queues with key COUNTERS:Ethernet7
2025-09-13T04:14:59.7023749Z --- PASS: TestGetQueueCounters (3.08s)
2025-09-13T04:14:59.7024434Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_NO_DATA (0.02s)
2025-09-13T04:14:59.7025064Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters (0.01s)
2025-09-13T04:14:59.7025557Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_trim_option_(trim=true) (0.01s)
2025-09-13T04:14:59.7026066Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(one_interface) (0.00s)
2025-09-13T04:14:59.7026733Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interface_arg (0.00s)
2025-09-13T04:14:59.7027224Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(two_interfaces) (0.01s)
2025-09-13T04:14:59.7027705Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_and_interface_arg (0.01s)
2025-09-13T04:14:59.7028192Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_and_interface_arg_with_overlap (0.01s)
2025-09-13T04:14:59.7028617Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_and_nonzero_options_(one_interface,_nonzero=true) (0.00s)
2025-09-13T04:14:59.7029093Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_and_nonzero_options_(one_interface,_nonzero=false) (0.00s)
2025-09-13T04:14:59.7029759Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces,_nonzero,_and_trim_options_(one_interface,_nonzero=true,_trim=true) (0.00s)
2025-09-13T04:14:59.7030306Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interface_arg_with_nonzero_and_trim_options_(nonzero=true,_trim=true) (0.00s)
2025-09-13T04:14:59.7030732Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interfaces_option_(invalid_interface) (0.00s)
2025-09-13T04:14:59.7031200Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_counters_interface_arg_(invalid_interface) (0.00s)
2025-09-13T04:14:59.7032385Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_NO_DATA (0.01s)
2025-09-13T04:14:59.7032690Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(all_interfaces) (0.01s)
2025-09-13T04:14:59.7032964Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface) (0.00s)
2025-09-13T04:14:59.7033235Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(two_interfaces) (0.01s)
2025-09-13T04:14:59.7033620Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_interface_arg (0.00s)
2025-09-13T04:14:59.7033906Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_interfaces_option_and_interface_arg (0.01s)
2025-09-13T04:14:59.7034221Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_interfaces_option_and_interface_arg_with_overlap (0.01s)
2025-09-13T04:14:59.7034529Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface,_nonzero=true) (0.00s)
2025-09-13T04:14:59.7034828Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_with_interface_arg_(nonzero=true) (0.00s)
2025-09-13T04:14:59.7035127Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(one_interface,_nonzero=false) (0.00s)
2025-09-13T04:14:59.7035410Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_(invalid_interface) (0.00s)
2025-09-13T04:14:59.7035704Z     --- PASS: TestGetQueueCounters/query_SHOW_queue_wredcounters_with_interface_arg_(invalid_interface) (0.00s)
```

Coverage results:
```
-------------
Diff Coverage
Diff: origin/202412-dev...HEAD and staged changes
-------------
show_client/queue_cli.go (100%)
show_client/show_paths.go (100%)
-------------
Total:   31 lines
Missing: 0 lines
Coverage: 100%
-------------
```


#### (Show command specific) Output of show CLI that is equivalent to API output
```
$ show queue wredcounters Ethernet0
     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
---------  -----  --------------  ---------------  ----------------  -----------------
Ethernet0    UC0              10             2560                20               5120
Ethernet0    UC1             N/A              N/A               N/A                N/A
Ethernet0    UC2             N/A              N/A               N/A                N/A
Ethernet0    UC3             N/A              N/A               N/A                N/A
Ethernet0    UC4             N/A              N/A               N/A                N/A
Ethernet0    UC5             N/A              N/A               N/A                N/A
Ethernet0    UC6             N/A              N/A               N/A                N/A
Ethernet0    UC7             N/A              N/A               N/A                N/A
Ethernet0    MC8             N/A              N/A               N/A                N/A
Ethernet0    MC9             N/A              N/A               N/A                N/A
Ethernet0   MC10             N/A              N/A               N/A                N/A
Ethernet0   MC11             N/A              N/A               N/A                N/A
Ethernet0   MC12             N/A              N/A               N/A                N/A
Ethernet0   MC13             N/A              N/A               N/A                N/A
Ethernet0   MC14             N/A              N/A               N/A                N/A
Ethernet0   MC15             N/A              N/A               N/A                N/A

$ show queue wredcounters Ethernet8
     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
---------  -----  --------------  ---------------  ----------------  -----------------
Ethernet8    UC0             N/A              N/A               N/A                N/A
Ethernet8    UC1             N/A              N/A               N/A                N/A
Ethernet8    UC2             N/A              N/A               N/A                N/A
Ethernet8    UC3             N/A              N/A               N/A                N/A
Ethernet8    UC4             N/A              N/A               N/A                N/A
Ethernet8    UC5               1              128                10               1280
Ethernet8    UC6             N/A              N/A               N/A                N/A
Ethernet8    UC7             N/A              N/A               N/A                N/A
Ethernet8    MC8             N/A              N/A               N/A                N/A
Ethernet8    MC9             N/A              N/A               N/A                N/A
Ethernet8   MC10             N/A              N/A               N/A                N/A
Ethernet8   MC11             N/A              N/A               N/A                N/A
Ethernet8   MC12             N/A              N/A               N/A                N/A
Ethernet8   MC13             N/A              N/A               N/A                N/A
Ethernet8   MC14             N/A              N/A               N/A                N/A
Ethernet8   MC15             N/A              N/A               N/A                N/A

```

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```
# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet0]" -xpath_target SHOW -insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757357290336976447
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet0"
        >
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:10\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:11\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:12\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:13\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:14\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:15\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:2\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:3\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:4\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:5\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:6\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:7\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:8\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:9\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"}}"
    >
  >
>

# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet0][nonzero=true]" -xpath_target SHOW -insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet0"
    >
    key: <
      key: "nonzero"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757357308674631902
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet0"
        >
        key: <
          key: "nonzero"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{},\"Ethernet0:10\":{},\"Ethernet0:11\":{},\"Ethernet0:12\":{},\"Ethernet0:13\":{},\"Ethernet0:14\":{},\"Ethernet0:15\":{},\"Ethernet0:2\":{},\"Ethernet0:3\":{},\"Ethernet0:4\":{},\"Ethernet0:5\":{},\"Ethernet0:6\":{},\"Ethernet0:7\":{},\"Ethernet0:8\":{},\"Ethernet0:9\":{}}"
    >
  >
>

# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet0,Ethernet8][nonzero=true]" -xpath_target SHOW -in
secure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet0,Ethernet8"
    >
    key: <
      key: "nonzero"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757357359076754579
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet0,Ethernet8"
        >
        key: <
          key: "nonzero"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{},\"Ethernet0:10\":{},\"Ethernet0:11\":{},\"Ethernet0:12\":{},\"Ethernet0:13\":{},\"Ethernet0:14\":{},\"Ethernet0:15\":{},\"Ethernet0:2\":{},\"Ethernet0:3\":{},\"Ethernet0:4\":{},\"Ethernet0:5\":{},\"Ethernet0:6\":{},\"Ethernet0:7\":{},\"Ethernet0:8\":{},\"Ethernet0:9\":{},\"Ethernet8:0\":{},\"Ethernet8:1\":{},\"Ethernet8:10\":{},\"Ethernet8:11\":{},\"Ethernet8:12\":{},\"Ethernet8:13\":{},\"Ethernet8:14\":{},\"Ethernet8:15\":{},\"Ethernet8:2\":{},\"Ethernet8:3\":{},\"Ethernet8:4\":{},\"Ethernet8:5\":{\"WredDrp/pkts\":\"1\",\"WredDrp/bytes\":\"128\",\"EcnMarked/pkts\":\"10\",\"EcnMarked/bytes\":\"1280\"},\"Ethernet8:6\":{},\"Ethernet8:7\":{},\"Ethernet8:8\":{},\"Ethernet8:9\":{}}"
    >
  >
>



# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[nonzero=true]/Ethernet0" -xpath_target SHOW -insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "nonzero"
      value: "true"
    >
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757735071243949441
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "nonzero"
          value: "true"
        >
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{},\"Ethernet0:10\":{},\"Ethernet0:11\":{},\"Ethernet0:12\":{},\"Ethernet0:13\":{},\"Ethernet0:14\":{},\"Ethernet0:15\":{},\"Ethernet0:2\":{},\"Ethernet0:3\":{},\"Ethernet0:4\":{},\"Ethernet0:5\":{},\"Ethernet0:6\":{},\"Ethernet0:7\":{},\"Ethernet0:8\":{},\"Ethernet0:9\":{}}"
    >
  >
>

# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet8]/Ethernet0" -xpath_target SHOW -insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet8"
    >
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757735106961137485
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet8"
        >
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:10\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:11\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:12\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:13\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:14\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:15\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:2\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:3\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:4\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:5\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:6\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:7\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:8\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:9\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:0\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:1\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:10\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:11\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:12\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:13\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:14\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:15\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:2\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:3\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:4\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:5\":{\"WredDrp/pkts\":\"1\",\"WredDrp/bytes\":\"128\",\"EcnMarked/pkts\":\"10\",\"EcnMarked/bytes\":\"1280\"},\"Ethernet8:6\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:7\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:8\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:9\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"}}"
    >
  >
>

# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet0,Ethernet8]/Ethernet0" -xpath_target SHOW -
insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet0,Ethernet8"
    >
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757735146480891284
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet0,Ethernet8"
        >
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:10\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:11\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:12\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:13\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:14\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:15\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:2\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:3\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:4\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:5\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:6\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:7\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:8\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet0:9\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:0\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:1\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:10\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:11\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:12\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:13\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:14\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:15\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:2\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:3\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:4\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:5\":{\"WredDrp/pkts\":\"1\",\"WredDrp/bytes\":\"128\",\"EcnMarked/pkts\":\"10\",\"EcnMarked/bytes\":\"1280\"},\"Ethernet8:6\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:7\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:8\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"},\"Ethernet8:9\":{\"WredDrp/pkts\":\"N/A\",\"WredDrp/bytes\":\"N/A\",\"EcnMarked/pkts\":\"N/A\",\"EcnMarked/bytes\":\"N/A\"}}"
    >
  >
>

# gnmi_get -target_addr 127.0.0.1:50051 -xpath "queue/wredcounters[interfaces=Ethernet0,Ethernet8][nonzero=true]/Ethernet0" -xpath
_target SHOW -insecure
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "queue"
  >
  elem: <
    name: "wredcounters"
    key: <
      key: "interfaces"
      value: "Ethernet0,Ethernet8"
    >
    key: <
      key: "nonzero"
      value: "true"
    >
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1757735158519041102
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "queue"
      >
      elem: <
        name: "wredcounters"
        key: <
          key: "interfaces"
          value: "Ethernet0,Ethernet8"
        >
        key: <
          key: "nonzero"
          value: "true"
        >
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0:0\":{\"WredDrp/pkts\":\"10\",\"WredDrp/bytes\":\"2560\",\"EcnMarked/pkts\":\"20\",\"EcnMarked/bytes\":\"5120\"},\"Ethernet0:1\":{},\"Ethernet0:10\":{},\"Ethernet0:11\":{},\"Ethernet0:12\":{},\"Ethernet0:13\":{},\"Ethernet0:14\":{},\"Ethernet0:15\":{},\"Ethernet0:2\":{},\"Ethernet0:3\":{},\"Ethernet0:4\":{},\"Ethernet0:5\":{},\"Ethernet0:6\":{},\"Ethernet0:7\":{},\"Ethernet0:8\":{},\"Ethernet0:9\":{},\"Ethernet8:0\":{},\"Ethernet8:1\":{},\"Ethernet8:10\":{},\"Ethernet8:11\":{},\"Ethernet8:12\":{},\"Ethernet8:13\":{},\"Ethernet8:14\":{},\"Ethernet8:15\":{},\"Ethernet8:2\":{},\"Ethernet8:3\":{},\"Ethernet8:4\":{},\"Ethernet8:5\":{\"WredDrp/pkts\":\"1\",\"WredDrp/bytes\":\"128\",\"EcnMarked/pkts\":\"10\",\"EcnMarked/bytes\":\"1280\"},\"Ethernet8:6\":{},\"Ethernet8:7\":{},\"Ethernet8:8\":{},\"Ethernet8:9\":{}}"
    >
  >
>
```
