### PR TITLE
Migrate option to argument for the command 'show ipv6 fib'

### DIFF
--- a/gnmi_server/ipv6_fib_cli_test.go
+++ b/gnmi_server/ipv6_fib_cli_test.go
@@ -74,7 +74,8 @@ func TestShowIPv6Fib_FilterByPrefix(t *testing.T) {
 	// Filter by exact prefix using option key "ipaddress"
 	textPbPath := `
         elem: <name: "ipv6" >
-        elem: <name: "fib"  key: { key: "ipaddress" value: "fc00:1::/64" } >
+        elem: <name: "fib"  >
+		elem: <name: "fc00:1::/64" >
     `
 
 	expected := []byte(`{

--- a/show_client/ipv6_fib_cli.go
+++ b/show_client/ipv6_fib_cli.go
@@ -9,7 +9,7 @@ import (
 )
 
 // https://github.com/Azure/sonic-utilities.msft/blob/master/scripts/fibshow
-// For command 'show ipv6 fib'  otption: ipv6address
+// For command 'show ipv6 fib'  arg: ipv6address
 // :~$ show ipv6 fib
 //
 //	No.  Vrf    Route           Nexthop    Ifname
@@ -23,14 +23,7 @@ import (
 // Total number of entries 3
 func getIPv6Fib(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 
-	var filter string
-	// TODO: cleanup constant and use args
-	if ov, ok := options[OptionKeyIpAddress]; ok {
-		if v, ok2 := ov.String(); ok2 {
-			filter = strings.TrimSpace(v)
-		}
-	}
-
+	filter := strings.TrimSpace(args.At(0))
 	entries, err := getFibEntries(filter, true) // true -> IPv6
 	if err != nil {
 		return nil, err

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -31,8 +31,7 @@ const (
 
 // Option keys
 const (
-	OptionKeyIpAddress = "ipaddress"
-	OptionKeyVerbose   = "verbose"
+	OptionKeyVerbose = "verbose"
 )
 
 var (
@@ -164,12 +163,6 @@ var (
 		"routes",
 		"advertised-routes",
 		"received-routes",
-	)
-
-	showCmdOptionIPV6Address = sdc.NewShowCmdOption(
-		OptionKeyIpAddress,
-		showCmdOptionIPV6AddressDesc,
-		sdc.StringValue,
 	)
 
 	showCmdOptionInfoTypeForBgpNetwork = sdc.NewShowCmdOption(

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -305,7 +305,6 @@ func init() {
 		0,
 		1,
 		nil,
-		showCmdOptionIPV6Address, // TODO
 		showCmdOptionVerbose,
 	)
 	sdc.RegisterCliPath(
@@ -417,15 +416,15 @@ func init() {
 			"memory":  "show/processes/memory: Show processes information sorted by memory usage",
 		},
 	)
-        sdc.RegisterCliPath(
-                []string{"SHOW", "processes", "memory"},
-                getTopMemoryUsage,
-                "SHOW/processes/memory[OPTIONS]: Show processes information sorted by memory usage",
-                0,
-                0,
-                nil,
-                showCmdOptionVerbose,
-        )
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "processes", "memory"},
+		getTopMemoryUsage,
+		"SHOW/processes/memory[OPTIONS]: Show processes information sorted by memory usage",
+		0,
+		0,
+		nil,
+		showCmdOptionVerbose,
+	)
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "processes", "summary"},
 		getProcessesSummary,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Migrating the command('show ipv6 fib') option to an argument, making it align with the command line.
#### How I did it
Migrating command option to argument
#### (SHOW command specific) What sources are you using to fetch data?

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
<img width="538" height="354" alt="image" src="https://github.com/user-attachments/assets/cdcf6250-1147-485a-8ef2-c07a61c4bdf3" />

#### (Show command specific) Output of show CLI that is equivalent to API output

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

#### A picture of a cute animal (not mandatory but encouraged)
