### PR TITLE
added show switch-trimming global command

### DIFF
--- a/gnmi_server/switch_trimming_global_cli_test.go
+++ b/gnmi_server/switch_trimming_global_cli_test.go
@@ -82,7 +82,7 @@ func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
 			wantRespVal: []byte(`{
 				"response": "No configuration is present in CONFIG DB"
 			}`),
-			valTest:     true,
+			valTest: true,
 			testInit: func() *gomonkey.Patches {
 				return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
 					return map[string]interface{}{}, nil

--- a/gnmi_server/switch_trimming_global_cli_test.go
+++ b/gnmi_server/switch_trimming_global_cli_test.go
@@ -1,0 +1,124 @@
+package gnmi
+
+import (
+        "context"
+        "crypto/tls"
+        "fmt"
+        "testing"
+        "time"
+
+        pb "github.com/openconfig/gnmi/proto/gnmi"
+        show_client "github.com/sonic-net/sonic-gnmi/show_client"
+
+        "github.com/agiledragon/gomonkey/v2"
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/codes"
+        "google.golang.org/grpc/credentials"
+)
+
+func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
+        s := createServer(t, ServerPort)
+        go runServer(t, s)
+        defer s.ForceStop()
+
+        tlsConfig := &tls.Config{InsecureSkipVerify: true}
+        opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+        conn, err := grpc.Dial(TargetAddr, opts...)
+        if err != nil {
+                t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+        }
+        defer conn.Close()
+
+        gClient := pb.NewGNMIClient(conn)
+        ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+        defer cancel()
+
+        expectedJSON := `{
+                "size": "64",
+                "dscp_value": "32",
+                "tc_value": "5",
+                "queue_index": "3"
+        }`
+
+        tests := []struct {
+                desc        string
+                pathTarget  string
+                textPbPath  string
+                wantRetCode codes.Code
+                wantRespVal interface{}
+                valTest     bool
+                testInit    func() *gomonkey.Patches
+        }{
+                {
+                        desc:       "query show switch-trimming with success case",
+                        pathTarget: "SHOW",
+                        textPbPath: `
+                        elem: <name: "switch-trimming" >
+                        elem: <name: "global" >
+                        `,
+                        wantRetCode: codes.OK,
+                        wantRespVal: []byte(expectedJSON),
+                        valTest:     true,
+                        testInit: func() *gomonkey.Patches {
+                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                        return map[string]interface{}{
+                                                "size":        "64",
+                                                "dscp_value":  "32",
+                                                "tc_value":    "5",
+                                                "queue_index": "3",
+                                        }, nil
+                                })
+                        },
+                },
+                {
+                        desc:       "query show switch-trimming with empty config",
+                        pathTarget: "SHOW",
+                        textPbPath: `
+                        elem: <name: "switch-trimming" >
+                        elem: <name: "global" >
+                        `,
+                        wantRetCode: codes.OK,
+                        wantRespVal: []byte(`{
+                                "response": "No configuration is present in CONFIG DB"
+                        }`),
+                        valTest:     true,
+                        testInit: func() *gomonkey.Patches {
+                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                        return map[string]interface{}{}, nil
+                                })
+                        },
+                },
+                {
+                        desc:       "query show switch-trimming with DB error",
+                        pathTarget: "SHOW",
+                        textPbPath: `
+                        elem: <name: "switch-trimming" >
+                        elem: <name: "global" >
+                        `,
+                        wantRetCode: codes.NotFound,
+                        wantRespVal: nil,
+                        valTest:     false,
+                        testInit: func() *gomonkey.Patches {
+                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                        return nil, fmt.Errorf("simulated DB failure")
+                                })
+                        },
+                },
+        }
+
+        for _, test := range tests {
+                var patch *gomonkey.Patches
+                if test.testInit != nil {
+                        patch = test.testInit()
+                }
+
+                t.Run(test.desc, func(t *testing.T) {
+                        runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+                })
+
+                if patch != nil {
+                        patch.Reset()
+                }
+        }
+}

--- a/gnmi_server/switch_trimming_global_cli_test.go
+++ b/gnmi_server/switch_trimming_global_cli_test.go
@@ -1,124 +1,124 @@
 package gnmi
 
 import (
-        "context"
-        "crypto/tls"
-        "fmt"
-        "testing"
-        "time"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+	"time"
 
-        pb "github.com/openconfig/gnmi/proto/gnmi"
-        common "github.com/sonic-net/sonic-gnmi/show_client/common"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	common "github.com/sonic-net/sonic-gnmi/show_client/common"
 
-        "github.com/agiledragon/gomonkey/v2"
-        "google.golang.org/grpc"
-        "google.golang.org/grpc/codes"
-        "google.golang.org/grpc/credentials"
+	"github.com/agiledragon/gomonkey/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 )
 
 func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
-        s := createServer(t, ServerPort)
-        go runServer(t, s)
-        defer s.ForceStop()
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
 
-        tlsConfig := &tls.Config{InsecureSkipVerify: true}
-        opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-        conn, err := grpc.Dial(TargetAddr, opts...)
-        if err != nil {
-                t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
-        }
-        defer conn.Close()
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
 
-        gClient := pb.NewGNMIClient(conn)
-        ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
-        defer cancel()
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
 
-        expectedJSON := `{
-                "size": "64",
-                "dscp_value": "32",
-                "tc_value": "5",
-                "queue_index": "3"
-        }`
+	expectedJSON := `{
+		"size": "64",
+		"dscp_value": "32",
+		"tc_value": "5",
+		"queue_index": "3"
+	}`
 
-        tests := []struct {
-                desc        string
-                pathTarget  string
-                textPbPath  string
-                wantRetCode codes.Code
-                wantRespVal interface{}
-                valTest     bool
-                testInit    func() *gomonkey.Patches
-        }{
-                {
-                        desc:       "query show switch-trimming with success case",
-                        pathTarget: "SHOW",
-                        textPbPath: `
-                        elem: <name: "switch-trimming" >
-                        elem: <name: "global" >
-                        `,
-                        wantRetCode: codes.OK,
-                        wantRespVal: []byte(expectedJSON),
-                        valTest:     true,
-                        testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
-                                        return map[string]interface{}{
-                                                "size":        "64",
-                                                "dscp_value":  "32",
-                                                "tc_value":    "5",
-                                                "queue_index": "3",
-                                        }, nil
-                                })
-                        },
-                },
-                {
-                        desc:       "query show switch-trimming with empty config",
-                        pathTarget: "SHOW",
-                        textPbPath: `
-                        elem: <name: "switch-trimming" >
-                        elem: <name: "global" >
-                        `,
-                        wantRetCode: codes.OK,
-                        wantRespVal: []byte(`{
-                                "response": "No configuration is present in CONFIG DB"
-                        }`),
-                        valTest:     true,
-                        testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
-                                        return map[string]interface{}{}, nil
-                                })
-                        },
-                },
-                {
-                        desc:       "query show switch-trimming with DB error",
-                        pathTarget: "SHOW",
-                        textPbPath: `
-                        elem: <name: "switch-trimming" >
-                        elem: <name: "global" >
-                        `,
-                        wantRetCode: codes.NotFound,
-                        wantRespVal: nil,
-                        valTest:     false,
-                        testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
-                                        return nil, fmt.Errorf("simulated DB failure")
-                                })
-                        },
-                },
-        }
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func() *gomonkey.Patches
+	}{
+		{
+			desc:       "query show switch-trimming with success case",
+			pathTarget: "SHOW",
+			textPbPath: `
+			elem: <name: "switch-trimming" >
+			elem: <name: "global" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedJSON),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"size":        "64",
+						"dscp_value":  "32",
+						"tc_value":    "5",
+						"queue_index": "3",
+					}, nil
+				})
+			},
+		},
+		{
+			desc:       "query show switch-trimming with empty config",
+			pathTarget: "SHOW",
+			textPbPath: `
+			elem: <name: "switch-trimming" >
+			elem: <name: "global" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(`{
+				"response": "No configuration is present in CONFIG DB"
+			}`),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{}, nil
+				})
+			},
+		},
+		{
+			desc:       "query show switch-trimming with DB error",
+			pathTarget: "SHOW",
+			textPbPath: `
+			elem: <name: "switch-trimming" >
+			elem: <name: "global" >
+			`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return nil, fmt.Errorf("simulated DB failure")
+				})
+			},
+		},
+	}
 
-        for _, test := range tests {
-                var patch *gomonkey.Patches
-                if test.testInit != nil {
-                        patch = test.testInit()
-                }
+	for _, test := range tests {
+		var patch *gomonkey.Patches
+		if test.testInit != nil {
+			patch = test.testInit()
+		}
 
-                t.Run(test.desc, func(t *testing.T) {
-                        runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
-                })
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
 
-                if patch != nil {
-                        patch.Reset()
-                }
-        }
+		if patch != nil {
+			patch.Reset()
+		}
+	}
 }

--- a/gnmi_server/switch_trimming_global_cli_test.go
+++ b/gnmi_server/switch_trimming_global_cli_test.go
@@ -8,7 +8,7 @@ import (
         "time"
 
         pb "github.com/openconfig/gnmi/proto/gnmi"
-        show_client "github.com/sonic-net/sonic-gnmi/show_client"
+        common "github.com/sonic-net/sonic-gnmi/show_client/common"
 
         "github.com/agiledragon/gomonkey/v2"
         "google.golang.org/grpc"
@@ -61,7 +61,7 @@ func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
                         wantRespVal: []byte(expectedJSON),
                         valTest:     true,
                         testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
                                         return map[string]interface{}{
                                                 "size":        "64",
                                                 "dscp_value":  "32",
@@ -84,7 +84,7 @@ func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
                         }`),
                         valTest:     true,
                         testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
                                         return map[string]interface{}{}, nil
                                 })
                         },
@@ -100,7 +100,7 @@ func TestGetSwitchTrimmingGlobalConfig(t *testing.T) {
                         wantRespVal: nil,
                         valTest:     false,
                         testInit: func() *gomonkey.Patches {
-                                return gomonkey.ApplyFunc(show_client.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+                                return gomonkey.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
                                         return nil, fmt.Errorf("simulated DB failure")
                                 })
                         },

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -617,4 +617,15 @@ func init() {
 		nil,
 		showCmdOptionVerbose,
 	)
+
+	//SHOW/switch-trimming
+	sdc.RegisterCliPath(
+                []string{"SHOW", "switch-trimming", "global"},
+                getSwitchTrimmingGlobalConfig,
+                "SHOW/switch-trimming/global[OPTIONS]: Show switch-trimming global config",
+                0,
+                0,
+                nil,
+                showCmdOptionVerbose,
+        )
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -636,12 +636,12 @@ func init() {
 
 	//SHOW/switch-trimming
 	sdc.RegisterCliPath(
-                []string{"SHOW", "switch-trimming", "global"},
-                getSwitchTrimmingGlobalConfig,
-                "SHOW/switch-trimming/global[OPTIONS]: Show switch-trimming global config",
-                0,
-                0,
-                nil,
-                showCmdOptionVerbose,
-        )
+		[]string{"SHOW", "switch-trimming", "global"},
+		getSwitchTrimmingGlobalConfig,
+		"SHOW/switch-trimming/global[OPTIONS]: Show switch-trimming global config",
+		0,
+		0,
+		nil,
+		showCmdOptionVerbose,
+	)
 }

--- a/show_client/switch_trimming_global_cli.go
+++ b/show_client/switch_trimming_global_cli.go
@@ -3,6 +3,7 @@ package show_client
 import (
         "encoding/json"
         "fmt"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
         sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
@@ -21,7 +22,7 @@ type SwitchTrimmingResponse struct {
 
 // getSwitchTrimmingGlobalConfig queries CONFIG_DB and returns JSON response
 func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-        row, err := GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
+        row, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
         if err != nil {
                 return nil, fmt.Errorf("failed to query CONFIG_DB: %w", err)
         }

--- a/show_client/switch_trimming_global_cli.go
+++ b/show_client/switch_trimming_global_cli.go
@@ -1,44 +1,44 @@
 package show_client
 
 import (
-        "encoding/json"
-        "fmt"
+	"encoding/json"
+	"fmt"
 	"github.com/sonic-net/sonic-gnmi/show_client/common"
-        sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
 const (
-        cfgSwitchTrimming = "SWITCH_TRIMMING"
-        cfgTrimKey        = "GLOBAL"
+	cfgSwitchTrimming = "SWITCH_TRIMMING"
+	cfgTrimKey        = "GLOBAL"
 )
 
 // SwitchTrimmingResponse defines the structured output
 type SwitchTrimmingResponse struct {
-        Size       string `json:"size"`
-        DSCPValue  string `json:"dscp_value"`
-        TCValue    string `json:"tc_value"`
-        QueueIndex string `json:"queue_index"`
+	Size       string `json:"size"`
+	DSCPValue  string `json:"dscp_value"`
+	TCValue    string `json:"tc_value"`
+	QueueIndex string `json:"queue_index"`
 }
 
 // getSwitchTrimmingGlobalConfig queries CONFIG_DB and returns JSON response
 func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-        row, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
-        if err != nil {
-                return nil, fmt.Errorf("failed to query CONFIG_DB: %w", err)
-        }
+	row, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query CONFIG_DB: %w", err)
+	}
 
-        if len(row) == 0 {
-                return json.MarshalIndent(map[string]string{
-                        "response": "No configuration is present in CONFIG DB",
-                }, "", "  ")
-        }
+	if len(row) == 0 {
+		return json.Marshal(map[string]string{
+			"response": "No configuration is present in CONFIG DB",
+		})
+	}
 
-        response := SwitchTrimmingResponse{
-                Size:       GetValueOrDefault(row, "size", "N/A"),
-                DSCPValue:  GetValueOrDefault(row, "dscp_value", "N/A"),
-                TCValue:    GetValueOrDefault(row, "tc_value", "N/A"),
-                QueueIndex: GetValueOrDefault(row, "queue_index", "N/A"),
-        }
+	response := SwitchTrimmingResponse{
+		Size:       GetValueOrDefault(row, "size", "N/A"),
+		DSCPValue:  GetValueOrDefault(row, "dscp_value", "N/A"),
+		TCValue:    GetValueOrDefault(row, "tc_value", "N/A"),
+		QueueIndex: GetValueOrDefault(row, "queue_index", "N/A"),
+	}
 
-        return json.Marshal(response)
+	return json.Marshal(response)
 }

--- a/show_client/switch_trimming_global_cli.go
+++ b/show_client/switch_trimming_global_cli.go
@@ -1,0 +1,53 @@
+package show_client
+
+import (
+        "encoding/json"
+        "fmt"
+        sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+const (
+        cfgSwitchTrimming = "SWITCH_TRIMMING"
+        cfgTrimKey        = "GLOBAL"
+)
+
+// SwitchTrimmingResponse defines the structured output
+type SwitchTrimmingResponse struct {
+        Size       string `json:"size"`
+        DSCPValue  string `json:"dscp_value"`
+        TCValue    string `json:"tc_value"`
+        QueueIndex string `json:"queue_index"`
+}
+
+// getOrNA returns the value for a key or "N/A" if missing or empty
+func getOrNA(entry map[string]interface{}, key string) string {
+        if val, ok := entry[key]; ok {
+                if str, ok := val.(string); ok && str != "" {
+                        return str
+                }
+        }
+        return "N/A"
+}
+
+// getSwitchTrimmingGlobalConfig queries CONFIG_DB and returns JSON response
+func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+        row, err := GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
+        if err != nil {
+                return nil, fmt.Errorf("failed to query CONFIG_DB: %w", err)
+        }
+
+        if len(row) == 0 {
+                return json.MarshalIndent(map[string]string{
+                        "response": "No configuration is present in CONFIG DB",
+                }, "", "  ")
+        }
+
+        response := SwitchTrimmingResponse{
+                Size:       getOrNA(row, "size"),
+                DSCPValue:  getOrNA(row, "dscp_value"),
+                TCValue:    getOrNA(row, "tc_value"),
+                QueueIndex: getOrNA(row, "queue_index"),
+        }
+
+        return json.MarshalIndent(response, "", "  ")
+}

--- a/show_client/switch_trimming_global_cli.go
+++ b/show_client/switch_trimming_global_cli.go
@@ -19,16 +19,6 @@ type SwitchTrimmingResponse struct {
         QueueIndex string `json:"queue_index"`
 }
 
-// getOrNA returns the value for a key or "N/A" if missing or empty
-func getOrNA(entry map[string]interface{}, key string) string {
-        if val, ok := entry[key]; ok {
-                if str, ok := val.(string); ok && str != "" {
-                        return str
-                }
-        }
-        return "N/A"
-}
-
 // getSwitchTrimmingGlobalConfig queries CONFIG_DB and returns JSON response
 func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
         row, err := GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
@@ -43,11 +33,11 @@ func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]b
         }
 
         response := SwitchTrimmingResponse{
-                Size:       getOrNA(row, "size"),
-                DSCPValue:  getOrNA(row, "dscp_value"),
-                TCValue:    getOrNA(row, "tc_value"),
-                QueueIndex: getOrNA(row, "queue_index"),
+                Size:       GetValueOrDefault(row, "size", "N/A"),
+                DSCPValue:  GetValueOrDefault(row, "dscp_value", "N/A"),
+                TCValue:    GetValueOrDefault(row, "tc_value", "N/A"),
+                QueueIndex: GetValueOrDefault(row, "queue_index", "N/A"),
         }
 
-        return json.MarshalIndent(response, "", "  ")
+        return json.Marshal(response)
 }

--- a/show_client/switch_trimming_global_cli.go
+++ b/show_client/switch_trimming_global_cli.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	cfgSwitchTrimming = "SWITCH_TRIMMING"
-	cfgTrimKey        = "GLOBAL"
+	CfgSwitchTrimming = "SWITCH_TRIMMING"
+	CfgTrimKey        = "GLOBAL"
 )
 
 // SwitchTrimmingResponse defines the structured output
@@ -22,7 +22,7 @@ type SwitchTrimmingResponse struct {
 
 // getSwitchTrimmingGlobalConfig queries CONFIG_DB and returns JSON response
 func getSwitchTrimmingGlobalConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	row, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", cfgSwitchTrimming, cfgTrimKey}})
+	row, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", CfgSwitchTrimming, CfgTrimKey}})
 	if err != nil {
 		return nil, fmt.Errorf("failed to query CONFIG_DB: %w", err)
 	}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
MS ADO: 34951294

#### Why I did it

Add gNMI getter for show switch-trimming global so clients can fetch it via gNMI in JSON.

#### How I did it

- Added switch_trimming_global_cli.go.
- Gets data from CONFIG_DB using GetMapFromQueries.
- Normalizes output (unmarshal/remarshal) and returns compact JSON.

#### (SHOW command specific) What sources are you using to fetch data?

CONFIG_DB

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)

<img width="943" height="516" alt="image" src="https://github.com/user-attachments/assets/0d876f4a-c9b7-4407-823c-fc1ca8e942f2" />


#### (Show command specific) Output of show CLI that is equivalent to API output

```
admin@<machine>~$ show switch-trimming global -j
No configuration is present in CONFIG DB
```

```
admin@<machine>:~$ show switch-trimming global -j
{
    "size": "128",
    "dscp_value": "32",
    "tc_value": "5",
    "queue_index": "3"
}
```

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

```
root@<machine>:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t <testbed-ip> -p 50051 -m get -x switch-trimming/global -xt SHOW -o ndastreamingser
vertest
/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if filter_event_regex is not "":
/root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(match) is not 0:
Performing GetRequest, encoding=JSON_IETF to <testbed-ip> with the following gNMI Path
 -------------------------
 [elem {
  name: "switch-trimming"
}
elem {
  name: "global"
}
]
The GetResponse is below
-------------------------

{
  "response": "No configuration is present in CONFIG DB"
}
-------------------------
```

```
root@<machine>:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t <testbed-ip> -p 50051 -m get -x switch-trimming/global -xt SHOW -o ndastreamingservertest
/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if filter_event_regex is not "":
/root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(match) is not 0:
Performing GetRequest, encoding=JSON_IETF to <testbed-ip>  with the following gNMI Path
 -------------------------
 [elem {
  name: "switch-trimming"
}
elem {
  name: "global"
}
]
The GetResponse is below
-------------------------

{
  "size": "128",
  "dscp_value": "32",
  "tc_value": "5",
  "queue_index": "3"
}
-------------------------
```
