### PR TITLE
Update show-interface-transceiver-lpmode interface option

### DIFF
--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -333,7 +333,7 @@ func init() {
 		0,
 		1,
 		nil,
-		showCmdOptionInterface, // TODO
+		showCmdOptionVerbose,
 	)
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "interfaces", "transceiver", "status"},


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

interface is arg not option that:
```shell
admin@str3-t0-8102-smartswitch-01:~$ show interface transceiver lpmode -h
Usage: show interface transceiver lpmode [OPTIONS] [INTERFACENAME]

  Show interface transceiver low-power mode status

Options:
  --verbose       Enable verbose output
  -?, -h, --help  Show this message and exit.
```

#### How I did it
remove interface option
