### PR TITLE
Make interface naming mode as Enum

### DIFF
--- a/gnmi_server/arp_cli_test.go
+++ b/gnmi_server/arp_cli_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
-	common "github.com/sonic-net/sonic-gnmi/show_client/common"
+	sccommon "github.com/sonic-net/sonic-gnmi/show_client/common"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -69,7 +69,7 @@ func TestGetArpTable(t *testing.T) {
 			wantRespVal: []byte(expectedArp),
 			valTest:     true,
 			testInit: func() *gomonkey.Patches {
-				return gomonkey.ApplyFunc(common.GetDataFromHostCommand, func(cmd string) (string, error) {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					return `
 					Address    MacAddress    Iface    Vlan
 					---------  ------------  -------  ------
@@ -93,7 +93,7 @@ func TestGetArpTable(t *testing.T) {
 			valTest:     true,
 			testInit: func() *gomonkey.Patches {
 				patches := gomonkey.NewPatches()
-				patches.ApplyFunc(common.GetDataFromHostCommand, func(cmd string) (string, error) {
+				patches.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					return `
 					Address    MacAddress    Iface    Vlan
 					---------  ------------  -------  ------
@@ -101,8 +101,8 @@ func TestGetArpTable(t *testing.T) {
 					Total number of entries 1
 					`, nil
 				})
-				patches.ApplyFunc(common.TryConvertInterfaceNameFromAlias, func(interfaceName string, namingMode string) (string, error) {
-					if interfaceName == "Ethernet0" && namingMode == "alias" {
+				patches.ApplyFunc(sccommon.TryConvertInterfaceNameFromAlias, func(interfaceName string, namingMode sccommon.InterfaceNamingMode) (string, error) {
+					if interfaceName == "Ethernet0" && namingMode == sccommon.Alias {
 						return "eth0", nil
 					}
 					return "", fmt.Errorf("mocked conversion failure")
@@ -124,7 +124,7 @@ func TestGetArpTable(t *testing.T) {
 			valTest:     false,
 			testInit: func() *gomonkey.Patches {
 				patches := gomonkey.NewPatches()
-				patches.ApplyFunc(common.GetDataFromHostCommand, func(cmd string) (string, error) {
+				patches.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					return `
 					Address    MacAddress    Iface    Vlan
 					---------  ------------  -------  ------
@@ -132,7 +132,7 @@ func TestGetArpTable(t *testing.T) {
 					Total number of entries 1
 					`, nil
 				})
-				patches.ApplyFunc(common.TryConvertInterfaceNameFromAlias, func(interfaceName string, namingMode string) (string, error) {
+				patches.ApplyFunc(sccommon.TryConvertInterfaceNameFromAlias, func(interfaceName string, namingMode sccommon.InterfaceNamingMode) (string, error) {
 					return "", fmt.Errorf("Cannot find interface name for alias %s", interfaceName)
 				})
 				return patches
@@ -148,7 +148,7 @@ func TestGetArpTable(t *testing.T) {
 			wantRespVal: []byte(`{"arp_entries":[]}`),
 			valTest:     true,
 			testInit: func() *gomonkey.Patches {
-				return gomonkey.ApplyFunc(common.GetDataFromHostCommand, func(cmd string) (string, error) {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					return `
 					Address    MacAddress    Iface    Vlan
 					---------  ------------  -------  ------
@@ -167,7 +167,7 @@ func TestGetArpTable(t *testing.T) {
 			wantRespVal: nil,
 			valTest:     false,
 			testInit: func() *gomonkey.Patches {
-				return gomonkey.ApplyFunc(common.GetDataFromHostCommand, func(cmd string) (string, error) {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					return "", fmt.Errorf("simulated command failure")
 				})
 			},

--- a/show_client/arp_cli.go
+++ b/show_client/arp_cli.go
@@ -2,9 +2,10 @@ package show_client
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/sonic-net/sonic-gnmi/show_client/common"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
-	"strings"
 )
 
 // Struct to represent each ARP entry
@@ -23,7 +24,11 @@ var (
 )
 
 func getArpTable(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		return nil, err
+	}
 	cmd := CmdPrefix
 
 	if len(args) > 0 && args[0] != "" {

--- a/show_client/interface_cli.go
+++ b/show_client/interface_cli.go
@@ -778,7 +778,12 @@ func getInterfaceStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 
 func getInterfaceAlias(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	intf := args.At(0)
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
 	// Read CONFIG_DB.PORT
 	queries := [][]string{{"CONFIG_DB", "PORT"}}
@@ -825,7 +830,12 @@ func getInterfaceAlias(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) 
 }
 
 func getInterfaceSwitchportConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
 	// Read CONFIG_DB tables
 	portTbl, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", "PORT"}})
@@ -906,7 +916,12 @@ func getInterfaceSwitchportConfig(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 }
 
 func getInterfaceSwitchportStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
 	// Read CONFIG_DB tables
 	portTbl, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", "PORT"}})
@@ -994,7 +1009,12 @@ func IsInterfaceInPortchannel(portchannelMemberTable map[string]interface{}, int
 
 func getInterfaceFlap(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	intf := args.At(0)
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
 	// Query APPL_DB PORT_TABLE
 	queries := [][]string{
@@ -1070,7 +1090,12 @@ func getInterfaceFlap(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 // 6) "BackEndLeafRouter"
 func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	intf := args.At(0)
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
 	neighborTbl, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", "DEVICE_NEIGHBOR"}})
 	if err != nil {
@@ -1148,9 +1173,13 @@ func getInterfaceNeighborExpected(args sdc.CmdArgs, options sdc.OptionMap) ([]by
 }
 
 func getInterfaceNamingMode(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid interface naming mode %q", namingModeStr)
+	}
 
-	namingMode = common.GetInterfaceNamingMode(namingMode)
-	namingModeResp := namingModeResponse{NamingMode: namingMode}
+	namingModeResp := namingModeResponse{NamingMode: namingMode.String()}
 	return json.Marshal(namingModeResp)
 }

--- a/show_client/interface_portchannel_cli.go
+++ b/show_client/interface_portchannel_cli.go
@@ -47,7 +47,11 @@ New JSON schema per PortChannel (key = numeric ID without 'PortChannel' prefix):
 	}
 */
 func getInterfacePortchannel(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		return nil, err
+	}
 	cfgPC, err := common.GetMapFromQueries([][]string{{"CONFIG_DB", "PORTCHANNEL"}})
 	if err != nil {
 		return nil, err
@@ -75,7 +79,7 @@ func getInterfacePortchannel(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, e
 		applLag:     applLag,
 		stateLagMem: stateLagMember,
 		applLagMem:  applLagMember,
-		aliasMode:   (namingMode == "alias"),
+		aliasMode:   (namingMode == common.Alias),
 	}
 
 	result := ts.getTeamshowResult(namingMode)
@@ -156,7 +160,7 @@ func (t *teamShow) getPortchannelMemberStatus(pc, member string) (bool, string) 
 }
 
 // Structured members list
-func (t *teamShow) getPortchannelMembers(pc string, namingMode string) []map[string]interface{} {
+func (t *teamShow) getPortchannelMembers(pc string, namingMode common.InterfaceNamingMode) []map[string]interface{} {
 	prefix := pc + "|"
 	var members []string
 	for k := range t.stateLagMem {
@@ -197,7 +201,7 @@ func getTeamID(team string) string {
 }
 
 // Build final structured result
-func (t *teamShow) getTeamshowResult(namingMode string) map[string]map[string]interface{} {
+func (t *teamShow) getTeamshowResult(namingMode common.InterfaceNamingMode) map[string]map[string]interface{} {
 	names := t.getPortchannelNames()
 	res := make(map[string]map[string]interface{}, len(names))
 	for _, pc := range names {

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -183,7 +183,12 @@ func getInterfaceTransceiverLpMode(args sdc.CmdArgs, options sdc.OptionMap) ([]b
 
 func getInterfaceTransceiverStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	intfArg := args.At(0)
-	namingMode, _ := options[SonicCliIfaceMode].String()
+	namingModeStr, _ := options[SonicCliIfaceMode].String()
+	namingMode, err := common.ParseInterfaceNamingMode(namingModeStr)
+	if err != nil {
+		log.Errorf("Failed to parse interface naming mode %s: %v", namingModeStr, err)
+		return nil, err
+	}
 
 	// APPL_DB PORT_TABLE -> determine valid ports
 	portTable, err := common.GetMapFromQueries([][]string{{common.ApplDb, common.AppDBPortTable}})

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -1,6 +1,7 @@
 package show_client
 
 import (
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
@@ -176,7 +177,9 @@ var (
 	showCmdOptionSonicCliIfaceMode = sdc.NewShowCmdOption(
 		SonicCliIfaceMode,
 		showCmdOptionSonicCliIfaceModeDesc,
-		sdc.StringValue,
+		sdc.EnumValue,
+		common.Default.String(),
+		common.Alias.String(),
 	)
 
 	showCmdOptionPrintAll = sdc.NewShowCmdOption(


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SONiC can display front‑panel ports using either internal kernel/DB names (e.g., Ethernet0) or user‑friendly aliases (e.g., Eth1, etp1, Gi0/1)
SONiC only supports 2 modes:
* default — shows kernel/DB port names like Ethernet0, Ethernet4, … 
* alias — shows the alias strings defined for your HW SKU (e.g., Eth1, etp1, or vendor‑style Gi0/1).

Since there're only2 modes can be supported, it's better to use strongly‑typed enum.

#### How I did it
1. Define type `InterfaceNamingMode` and 2 constant variables: `Default` and `Alias`
2. Replace existing usage of string type namingMode to type InterfaceNamingMode

#### (SHOW command specific) What sources are you using to fetch data?
N/A
#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)
N/A
#### (Show command specific) Output of show CLI that is equivalent to API output
N/A
#### Manual test output of API on device (Please provide output from device that you have tested your changes on)
```shell
root@str5-7060x6-moby-512-5:/# gnmi_get -xpath_target SHOW -xpath interfaces/alias[SONIC_CLI_IFACE_MODE=xx] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interfaces"
  >
  elem: <
    name: "alias"
    key: <
      key: "SONIC_CLI_IFACE_MODE"
      value: "xx"
    >
  >
>
encoding: JSON_IETF

F0925 06:30:31.709945  481592 gnmi_get.go:145] Get failed: rpc error: code = InvalidArgument desc = option SONIC_CLI_IFACE_MODE expects one of [default, alias] (got xx)
```
#### A picture of a cute animal (not mandatory but encouraged)
N/A