### PR TITLE
Update "show interfaces neighbor expected" interface option

### DIFF
--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -129,7 +129,7 @@ func init() {
 			"trim":          "show/interfaces/counters/trim: Show interface counters trim",
 		},
 		sdc.UnimplementedOption(showCmdOptionNamespace),
-		showCmdOptionPrintAll, 
+		showCmdOptionPrintAll,
 		showCmdOptionDisplay,
 		showCmdOptionInterfaces,
 		showCmdOptionPeriod,
@@ -263,7 +263,6 @@ func init() {
 		0,
 		1,
 		nil,
-		showCmdOptionInterface, // TODO: Take as arg not option
 		showCmdOptionSonicCliIfaceMode,
 	)
 	sdc.RegisterCliPath(
@@ -343,8 +342,8 @@ func init() {
 		1,
 		nil,
 		sdc.UnimplementedOption(showCmdOptionNamespace),
-  )
-  sdc.RegisterCliPath(
+	)
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "interfaces", "transceiver", "status"},
 		getInterfaceTransceiverStatus,
 		"SHOW/interfaces/transceiver/status/{INTERFACENAME}[OPTIONS]: Show interface transceiver status",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
interface is arg not option that:
```
:~$ show interfaces neighbor expected -h
Usage: show interfaces neighbor expected [OPTIONS] [INTERFACENAME]

  Show expected neighbor information by interfaces

Options:
  -n, --namespace []  Namespace name or all
  -h, -?, --help      Show this message and exit.
```


