### PR TITLE
Add hidden global option "redact" and add them to reboot-cause paths

### DIFF
--- a/gnmi_server/reboot_cause_cli_test.go
+++ b/gnmi_server/reboot_cause_cli_test.go
@@ -38,8 +38,11 @@ func TestGetShowRebootCause(t *testing.T) {
 	defer cancel()
 
 	rebootCauseReboot := `{"gen_time": "2025_07_09_17_32_14", "cause": "reboot", "user": "admin", "time": "Wed Jul  9 05:28:24 PM UTC 2025", "comment": "N/A"}`
+	rebootCauseRebootRedacted := `{"cause":"reboot","comment":"N/A","gen_time":"2025_07_09_17_32_14","time":"Wed Jul  9 05:28:24 PM UTC 2025","user":"[REDACTED]"}`
 	rebootCausePowerLoss := `{"gen_time": "2025_07_10_12_19_14", "cause": "Power Loss", "user": "N/A", "time": "Thur Jul  10 00:14:24 PM UTC 2025", "comment": "N/A"}`
+	rebootCausePowerLossRedacted := `{"cause":"Power Loss","comment":"N/A","gen_time":"2025_07_10_12_19_14","time":"Thur Jul  10 00:14:24 PM UTC 2025","user":"[REDACTED]"}`
 	rebootCauseHardware := `{"gen_time": "2025_07_08_11_53_50", "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)", "user": "N/A", "time": "N/A", "comment": "Unknown"}`
+	rebootCauseHardwareRedacted := `{"cause":"Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)","comment":"Unknown","gen_time":"2025_07_08_11_53_50","time":"N/A","user":"[REDACTED]"}`
 
 	tests := []struct {
 		desc        string
@@ -59,10 +62,11 @@ func TestGetShowRebootCause(t *testing.T) {
 			wantRetCode: codes.NotFound,
 		},
 		{
-			desc:       "query SHOW reboot-cause reboot",
+			desc:       "query SHOW reboot-cause reboot redact=false",
 			pathTarget: "SHOW",
 			textPbPath: `
-				elem: <name: "reboot-cause" >
+				elem: <name: "reboot-cause"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseReboot),
@@ -72,10 +76,24 @@ func TestGetShowRebootCause(t *testing.T) {
 			},
 		},
 		{
-			desc:       "query SHOW reboot-cause Power Loss",
+			desc:       "query SHOW reboot-cause reboot redacted",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseRebootRedacted),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCauseReboot, nil)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause Power Loss redact=false",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCausePowerLoss),
@@ -85,13 +103,40 @@ func TestGetShowRebootCause(t *testing.T) {
 			},
 		},
 		{
-			desc:       "query SHOW reboot-cause Hardware",
+			desc:       "query SHOW reboot-cause Power Loss redacted",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
 			`,
 			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCausePowerLossRedacted),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCausePowerLoss, nil)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause Hardware redact=false",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause"
+				      key: { key: "redact" value: "false" }>
+			`,
+			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseHardware),
+			valTest:     true,
+			testInit: func() {
+				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCauseHardware, nil)
+			},
+		},
+		{
+			desc:       "query SHOW reboot-cause Hardware redacted",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHardwareRedacted),
 			valTest:     true,
 			testInit: func() {
 				MockReadFile(show_client.PreviousRebootCauseFilePath, rebootCauseHardware, nil)
@@ -130,12 +175,16 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 
 	rebootCauseHistoryWatchdogFileName := "../testdata/REBOOT_CAUSE_WATCHDOG.txt"
 	rebootCauseHistoryWatchdog := `{"2025_07_10_20_06_34":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:05:33 PM UTC 2025","user":"admin"},"2025_07_10_20_12_49":{"cause":"fast-reboot","comment":"N/A","time":"Thu Jul 10 08:10:49 PM UTC 2025","user":"admin"},"2025_07_10_20_19_34":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 08:17:34 PM UTC 2025","user":"admin"},"2025_07_10_20_31_14":{"cause":"Watchdog (watchdog, description: Watchdog fired, time: 2025-07-10 20:30:26)","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_10_20_36_35":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:35:34 PM UTC 2025","user":"admin"},"2025_07_10_20_41_54":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:40:52 PM UTC 2025","user":"admin"},"2025_07_10_20_47_15":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:46:13 PM UTC 2025","user":"admin"},"2025_07_11_01_49_30":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:48:29 AM UTC 2025","user":"admin"},"2025_07_11_02_00_24":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:59:22 AM UTC 2025","user":"admin"},"2025_07_11_02_35_51":{"cause":"Unknown","comment":"N/A","time":"N/A","user":"N/A"}}`
+	rebootCauseHistoryWatchdogRedacted := `{"2025_07_10_20_06_34":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:05:33 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_20_12_49":{"cause":"fast-reboot","comment":"N/A","time":"Thu Jul 10 08:10:49 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_20_19_34":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 08:17:34 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_20_31_14":{"cause":"Watchdog (watchdog, description: Watchdog fired, time: 2025-07-10 20:30:26)","comment":"Unknown","time":"N/A","user":"[REDACTED]"},"2025_07_10_20_36_35":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:35:34 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_20_41_54":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:40:52 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_20_47_15":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 08:46:13 PM UTC 2025","user":"[REDACTED]"},"2025_07_11_01_49_30":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:48:29 AM UTC 2025","user":"[REDACTED]"},"2025_07_11_02_00_24":{"cause":"reboot","comment":"N/A","time":"Fri Jul 11 01:59:22 AM UTC 2025","user":"[REDACTED]"},"2025_07_11_02_35_51":{"cause":"Unknown","comment":"N/A","time":"N/A","user":"[REDACTED]"}}`
 	rebootCauseHistoryHardwareFileName := "../testdata/REBOOT_CAUSE_HARDWARE.txt"
 	rebootCauseHistoryHardware := `{"2025_07_07_02_35_26":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:34:07 AM UTC 2025","user":"admin"},"2025_07_07_02_43_43":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:42:22 AM UTC 2025","user":"admin"},"2025_07_08_05_22_02":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:20:54 AM UTC 2025","user":"admin"},"2025_07_08_05_30_28":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:29:20 AM UTC 2025","user":"admin"},"2025_07_08_07_00_08":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:59:00 AM UTC 2025","user":"admin"},"2025_07_08_09_21_21":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:20:13 AM UTC 2025","user":""},"2025_07_08_09_29_39":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:28:30 AM UTC 2025","user":"admin"},"2025_07_08_10_13_31":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 10:12:23 AM UTC 2025","user":"admin"},"2025_07_08_11_53_50":{"cause":"Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_08_18_29_38":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:28:26 PM UTC 2025","user":"admin"}}`
+	rebootCauseHistoryHardwareRedacted := `{"2025_07_07_02_35_26":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:34:07 AM UTC 2025","user":"[REDACTED]"},"2025_07_07_02_43_43":{"cause":"reboot","comment":"N/A","time":"Mon Jul  7 02:42:22 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_05_22_02":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:20:54 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_05_30_28":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 05:29:20 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_07_00_08":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:59:00 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_09_21_21":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:20:13 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_09_29_39":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 09:28:30 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_10_13_31":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 10:12:23 AM UTC 2025","user":"[REDACTED]"},"2025_07_08_11_53_50":{"cause":"Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)","comment":"Unknown","time":"N/A","user":"[REDACTED]"},"2025_07_08_18_29_38":{"cause":"reboot","comment":"N/A","time":"Tue Jul  8 06:28:26 PM UTC 2025","user":"[REDACTED]"}}`
 	rebootCauseHistoryKernelFileName := "../testdata/REBOOT_CAUSE_KERNEL.txt"
 	rebootCauseHistoryKernel := `{"2025_07_10_14_39_01":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:34:54 PM UTC 2025","user":"admin"},"2025_07_10_14_55_20":{"cause":"Kernel Panic","comment":"N/A","time":"Thu Jul 10 02:51:53 PM UTC 2025","user":"N/A"},"2025_07_10_15_13_45":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:09:38 PM UTC 2025","user":"admin"},"2025_07_10_15_29_52":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:25:44 PM UTC 2025","user":"admin"},"2025_07_10_15_45_47":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:41:43 PM UTC 2025","user":"admin"},"2025_07_10_18_03_28":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:59:18 PM UTC 2025","user":"admin"},"2025_07_10_23_33_47":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:29:44 PM UTC 2025","user":"admin"},"2025_07_10_23_48_41":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:44:41 PM UTC 2025","user":"admin"},"2025_07_11_00_51_52":{"cause":"warm-reboot","comment":"N/A","time":"Fri Jul 11 12:49:13 AM UTC 2025","user":"admin"},"2025_07_11_01_00_54":{"cause":"Kernel Panic","comment":"N/A","time":"Fri Jul 11 12:57:23 AM UTC 2025","user":"N/A"}}`
+	rebootCauseHistoryKernelRedacted := `{"2025_07_10_14_39_01":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:34:54 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_14_55_20":{"cause":"Kernel Panic","comment":"N/A","time":"Thu Jul 10 02:51:53 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_15_13_45":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:09:38 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_15_29_52":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:25:44 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_15_45_47":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 03:41:43 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_18_03_28":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:59:18 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_23_33_47":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:29:44 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_23_48_41":{"cause":"warm-reboot","comment":"N/A","time":"Thu Jul 10 11:44:41 PM UTC 2025","user":"[REDACTED]"},"2025_07_11_00_51_52":{"cause":"warm-reboot","comment":"N/A","time":"Fri Jul 11 12:49:13 AM UTC 2025","user":"[REDACTED]"},"2025_07_11_01_00_54":{"cause":"Kernel Panic","comment":"N/A","time":"Fri Jul 11 12:57:23 AM UTC 2025","user":"[REDACTED]"}}`
 	rebootCauseHistoryPowerLossFileName := "../testdata/REBOOT_CAUSE_POWER_LOSS.txt"
 	rebootCauseHistoryPowerLoss := `{"2025_07_09_04_44_38":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 04:41:09 AM UTC 2025","user":"admin"},"2025_07_09_05_11_26":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:07:59 AM UTC 2025","user":"admin"},"2025_07_09_06_52_52":{"cause":"fast-reboot","comment":"N/A","time":"Wed Jul  9 06:50:57 AM UTC 2025","user":"admin"},"2025_07_09_09_23_16":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_09_09_33_28":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_09_17_46_25":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:42:44 PM UTC 2025","user":"admin"},"2025_07_10_02_58_57":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:55:28 AM UTC 2025","user":""},"2025_07_10_05_00_09":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"N/A"},"2025_07_10_05_27_16":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:23:48 AM UTC 2025","user":"admin"},"2025_07_10_06_31_24":{"cause":"Kernel Panic - Out of memory [Time: Thu Jul 10 06:28:29 AM UTC 2025]","comment":"N/A","time":"N/A","user":"N/A"}}`
+	rebootCauseHistoryPowerLossRedacted := `{"2025_07_09_04_44_38":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 04:41:09 AM UTC 2025","user":"[REDACTED]"},"2025_07_09_05_11_26":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:07:59 AM UTC 2025","user":"[REDACTED]"},"2025_07_09_06_52_52":{"cause":"fast-reboot","comment":"N/A","time":"Wed Jul  9 06:50:57 AM UTC 2025","user":"[REDACTED]"},"2025_07_09_09_23_16":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"[REDACTED]"},"2025_07_09_09_33_28":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"[REDACTED]"},"2025_07_09_17_46_25":{"cause":"reboot","comment":"N/A","time":"Wed Jul  9 05:42:44 PM UTC 2025","user":"[REDACTED]"},"2025_07_10_02_58_57":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 02:55:28 AM UTC 2025","user":"[REDACTED]"},"2025_07_10_05_00_09":{"cause":"Power Loss","comment":"Unknown","time":"N/A","user":"[REDACTED]"},"2025_07_10_05_27_16":{"cause":"reboot","comment":"N/A","time":"Thu Jul 10 05:23:48 AM UTC 2025","user":"[REDACTED]"},"2025_07_10_06_31_24":{"cause":"Kernel Panic - Out of memory [Time: Thu Jul 10 06:28:29 AM UTC 2025]","comment":"N/A","time":"N/A","user":"[REDACTED]"}}`
 
 	ResetDataSetsAndMappings(t)
 
@@ -158,11 +207,12 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 			wantRetCode: codes.OK,
 		},
 		{
-			desc:       "query SHOW reboot-cause history watchdog",
+			desc:       "query SHOW reboot-cause history watchdog redact=false",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
-				elem: <name: "history" >
+				elem: <name: "history"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseHistoryWatchdog),
@@ -172,11 +222,23 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 			},
 		},
 		{
-			desc:       "query SHOW reboot-cause history hardware",
+			desc:       "query SHOW reboot-cause history watchdog redacted",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
 				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryWatchdogRedacted),
+			valTest:     true,
+		},
+		{
+			desc:       "query SHOW reboot-cause history hardware redact=false",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseHistoryHardware),
@@ -187,11 +249,23 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 			},
 		},
 		{
-			desc:       "query SHOW reboot-cause history kernel",
+			desc:       "query SHOW reboot-cause history hardware redacted",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
 				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryHardwareRedacted),
+			valTest:     true,
+		},
+		{
+			desc:       "query SHOW reboot-cause history kernel redact=false",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseHistoryKernel),
@@ -202,11 +276,23 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 			},
 		},
 		{
-			desc:       "query SHOW reboot-cause history power loss",
+			desc:       "query SHOW reboot-cause history kernel redacted",
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "reboot-cause" >
 				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryKernelRedacted),
+			valTest:     true,
+		},
+		{
+			desc:       "query SHOW reboot-cause history power loss redact=false",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history"
+				      key: { key: "redact" value: "false" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(rebootCauseHistoryPowerLoss),
@@ -215,6 +301,17 @@ func TestGetShowRebootCauseHistory(t *testing.T) {
 				FlushDataSet(t, StateDbNum)
 				AddDataSet(t, StateDbNum, rebootCauseHistoryPowerLossFileName)
 			},
+		},
+		{
+			desc:       "query SHOW reboot-cause history power loss redacted",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "reboot-cause" >
+				elem: <name: "history" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(rebootCauseHistoryPowerLossRedacted),
+			valTest:     true,
 		},
 	}
 

--- a/show_client/common/file.go
+++ b/show_client/common/file.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -62,4 +63,19 @@ func FileExists(path string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+func GetMapFromFile(filePath string) (map[string]interface{}, error) {
+	jsonBytes, err := GetDataFromFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON from %s: %w", filePath, err)
+	}
+
+	return result, nil
 }

--- a/show_client/common/redact.go
+++ b/show_client/common/redact.go
@@ -1,0 +1,38 @@
+package common
+
+// RedactSensitiveData creates a deep copy of the input map and redacts specified keys.
+// Redaction is performed at the top level only - nested values are not traversed.
+// Assumes map values are primitive types (string, number, bool, nil) only.
+// Returns (nil, nil) for nil input, and a deep copy with no redactions for empty/nil keys.
+func RedactSensitiveData(msi map[string]interface{}, keys []string) (map[string]interface{}, error) {
+	// Handle nil input
+	if msi == nil {
+		return nil, nil
+	}
+
+	// Create shallow copy (sufficient for primitive values)
+	result := make(map[string]interface{}, len(msi))
+	for key, value := range msi {
+		result[key] = value
+	}
+
+	// If no keys provided, return the copy with no redactions
+	if len(keys) == 0 {
+		return result, nil
+	}
+
+	// Build key lookup map for O(1) checking
+	keySet := make(map[string]bool)
+	for _, k := range keys {
+		keySet[k] = true
+	}
+
+	// Redact only at top level
+	for key := range result {
+		if keySet[key] {
+			result[key] = "[REDACTED]"
+		}
+	}
+
+	return result, nil
+}

--- a/show_client/common/redact.go
+++ b/show_client/common/redact.go
@@ -1,38 +1,32 @@
 package common
 
-// RedactSensitiveData creates a deep copy of the input map and redacts specified keys.
-// Redaction is performed at the top level only - nested values are not traversed.
-// Assumes map values are primitive types (string, number, bool, nil) only.
-// Returns (nil, nil) for nil input, and a deep copy with no redactions for empty/nil keys.
-func RedactSensitiveData(msi map[string]interface{}, keys []string) (map[string]interface{}, error) {
-	// Handle nil input
+const redactedString = "[REDACTED]"
+
+// Redaction is performed at the top level only and only supports when map values are primitive types only.
+func RedactSensitiveData(msi map[string]interface{}, keys []string) (map[string]interface{}) {
 	if msi == nil {
-		return nil, nil
+		return nil
 	}
 
-	// Create shallow copy (sufficient for primitive values)
 	result := make(map[string]interface{}, len(msi))
 	for key, value := range msi {
 		result[key] = value
 	}
 
-	// If no keys provided, return the copy with no redactions
 	if len(keys) == 0 {
-		return result, nil
+		return result
 	}
 
-	// Build key lookup map for O(1) checking
 	keySet := make(map[string]bool)
 	for _, k := range keys {
 		keySet[k] = true
 	}
 
-	// Redact only at top level
 	for key := range result {
 		if keySet[key] {
-			result[key] = "[REDACTED]"
+			result[key] = redactedString
 		}
 	}
 
-	return result, nil
+	return result
 }

--- a/show_client/reboot_cause_cli.go
+++ b/show_client/reboot_cause_cli.go
@@ -23,13 +23,7 @@ func getPreviousRebootCause(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, er
 			return nil, err
 		}
 
-		redactedMSI, err := common.RedactSensitiveData(msi, []string{"user"})
-		if err != nil {
-			log.Errorf("Unable to redact data, got err: %v", err)
-			return nil, err
-		}
-
-		return json.Marshal(redactedMSI)
+		return json.Marshal(common.RedactSensitiveData(msi, []string{"user"}))
 	}
 	return common.GetDataFromFile(PreviousRebootCauseFilePath)
 }
@@ -61,12 +55,7 @@ func getRebootCauseHistory(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, err
 		// Iterate through each timestamp entry and redact the nested map
 		for key, value := range msi {
 			if nestedMap, ok := value.(map[string]interface{}); ok {
-				redactedNested, err := common.RedactSensitiveData(nestedMap, []string{"user"})
-				if err != nil {
-					log.Errorf("Unable to redact nested data for key %v, got err: %v", key, err)
-					return nil, err
-				}
-				msi[key] = redactedNested
+				msi[key] = common.RedactSensitiveData(nestedMap, []string{"user"})
 			}
 		}
 

--- a/show_client/reboot_cause_cli.go
+++ b/show_client/reboot_cause_cli.go
@@ -38,28 +38,19 @@ func getRebootCauseHistory(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, err
 		{"STATE_DB", "REBOOT_CAUSE"},
 	}
 
-	data, err := common.GetDataFromQueries(queries)
-	if err != nil {
-		log.Errorf("Unable to get data from queries %v, got err: %v", queries, err)
-		return nil, err
-	}
-
 	if redact {
-		var msi map[string]interface{}
-		err = json.Unmarshal(data, &msi)
+		msi, err := common.GetMapFromQueries(queries)
 		if err != nil {
-			log.Errorf("Unable to parse JSON, got err: %v", err)
+			log.Errorf("Unable to get data from queries %v, got err: %v", queries, err)
 			return nil, err
 		}
-
-		// Iterate through each timestamp entry and redact the nested map
+		// Redact user in each reboot cause entry
 		for key, value := range msi {
 			if nestedMap, ok := value.(map[string]interface{}); ok {
 				msi[key] = common.RedactSensitiveData(nestedMap, []string{"user"})
 			}
 		}
-
 		return json.Marshal(msi)
 	}
-	return data, nil
+	return common.GetDataFromQueries(queries)
 }

--- a/show_client/reboot_cause_cli.go
+++ b/show_client/reboot_cause_cli.go
@@ -9,15 +9,32 @@ import (
 const PreviousRebootCauseFilePath = "/host/reboot-cause/previous-reboot-cause.json"
 
 func getPreviousRebootCause(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	// Redact by default unless explicitly set to false
+	redact := true
+	if redactOption, ok := options["redact"].Bool(); ok {
+		redact = redactOption
+	}
 	data, err := common.GetDataFromFile(PreviousRebootCauseFilePath)
 	if err != nil {
 		log.Errorf("Unable to get data from file %v, got err: %v", PreviousRebootCauseFilePath, err)
 		return nil, err
 	}
+	if redact {
+		data, err = common.RedactSensitiveData(data)
+		if err != nil {
+			log.Errorf("Failed to redact data: %v", err)
+			return nil, err
+		}
+	}
 	return data, nil
 }
 
 func getRebootCauseHistory(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	// Redact by default unless explicitly set to false
+	redact := true
+	if redactOption, ok := options["redact"].Bool(); ok {
+		redact = redactOption
+	}
 	queries := [][]string{
 		{"STATE_DB", "REBOOT_CAUSE"},
 	}
@@ -25,6 +42,13 @@ func getRebootCauseHistory(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, err
 	if err != nil {
 		log.Errorf("Unable to get data from queries %v, got err: %v", queries, err)
 		return nil, err
+	}
+	if redact {
+		data, err = common.RedactSensitiveData(data)
+		if err != nil {
+			log.Errorf("Failed to redact data: %v", err)
+			return nil, err
+		}
 	}
 	return data, nil
 }

--- a/show_client/reboot_cause_cli.go
+++ b/show_client/reboot_cause_cli.go
@@ -1,6 +1,8 @@
 package show_client
 
 import (
+	"encoding/json"
+
 	log "github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/show_client/common"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
@@ -9,46 +11,66 @@ import (
 const PreviousRebootCauseFilePath = "/host/reboot-cause/previous-reboot-cause.json"
 
 func getPreviousRebootCause(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	// Redact by default unless explicitly set to false
 	redact := true
 	if redactOption, ok := options["redact"].Bool(); ok {
 		redact = redactOption
 	}
-	data, err := common.GetDataFromFile(PreviousRebootCauseFilePath)
-	if err != nil {
-		log.Errorf("Unable to get data from file %v, got err: %v", PreviousRebootCauseFilePath, err)
-		return nil, err
-	}
+
 	if redact {
-		data, err = common.RedactSensitiveData(data)
+		msi, err := common.GetMapFromFile(PreviousRebootCauseFilePath)
 		if err != nil {
-			log.Errorf("Failed to redact data: %v", err)
+			log.Errorf("Unable to read JSON from file %v, got err: %v", PreviousRebootCauseFilePath, err)
 			return nil, err
 		}
+
+		redactedMSI, err := common.RedactSensitiveData(msi, []string{"user"})
+		if err != nil {
+			log.Errorf("Unable to redact data, got err: %v", err)
+			return nil, err
+		}
+
+		return json.Marshal(redactedMSI)
 	}
-	return data, nil
+	return common.GetDataFromFile(PreviousRebootCauseFilePath)
 }
 
 func getRebootCauseHistory(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	// Redact by default unless explicitly set to false
 	redact := true
 	if redactOption, ok := options["redact"].Bool(); ok {
 		redact = redactOption
 	}
+
 	queries := [][]string{
 		{"STATE_DB", "REBOOT_CAUSE"},
 	}
+
 	data, err := common.GetDataFromQueries(queries)
 	if err != nil {
 		log.Errorf("Unable to get data from queries %v, got err: %v", queries, err)
 		return nil, err
 	}
+
 	if redact {
-		data, err = common.RedactSensitiveData(data)
+		var msi map[string]interface{}
+		err = json.Unmarshal(data, &msi)
 		if err != nil {
-			log.Errorf("Failed to redact data: %v", err)
+			log.Errorf("Unable to parse JSON, got err: %v", err)
 			return nil, err
 		}
+
+		// Iterate through each timestamp entry and redact the nested map
+		for key, value := range msi {
+			if nestedMap, ok := value.(map[string]interface{}); ok {
+				redactedNested, err := common.RedactSensitiveData(nestedMap, []string{"user"})
+				if err != nil {
+					log.Errorf("Unable to redact nested data for key %v, got err: %v", key, err)
+					return nil, err
+				}
+				msi[key] = redactedNested
+			}
+		}
+
+		return json.Marshal(msi)
 	}
 	return data, nil
 }

--- a/sonic_data_client/show_client_helpers.go
+++ b/sonic_data_client/show_client_helpers.go
@@ -174,6 +174,11 @@ func constructDescription(usage string, subcommandDesc map[string]string, option
 	description["usage"] = make(map[string]string)
 
 	for _, option := range options {
+		// Skip hidden options from help output
+		if option.hidden {
+			continue
+		}
+
 		// Base description
 		desc := option.description
 
@@ -192,9 +197,16 @@ func constructDescription(usage string, subcommandDesc map[string]string, option
 
 func constructOptions(options []ShowCmdOption) map[string]ShowCmdOption {
 	pathOptions := make(map[string]ShowCmdOption)
-	pathOptions[showCmdOptionHelp.optName] = showCmdOptionHelp
+
+	// Step 1: Inject all registered global options
+	for _, globalOpt := range registeredGlobalOptions {
+		pathOptions[globalOpt.optName] = globalOpt
+	}
+
+	// Step 2: Add command-specific options (overwrites globals if names collide)
 	for _, option := range options {
 		pathOptions[option.optName] = option
 	}
+
 	return pathOptions
 }

--- a/sonic_data_client/show_client_helpers.go
+++ b/sonic_data_client/show_client_helpers.go
@@ -174,11 +174,9 @@ func constructDescription(usage string, subcommandDesc map[string]string, option
 	description["usage"] = make(map[string]string)
 
 	for _, option := range options {
-		// Skip hidden options from help output
 		if option.hidden {
 			continue
 		}
-
 		// Base description
 		desc := option.description
 
@@ -197,16 +195,11 @@ func constructDescription(usage string, subcommandDesc map[string]string, option
 
 func constructOptions(options []ShowCmdOption) map[string]ShowCmdOption {
 	pathOptions := make(map[string]ShowCmdOption)
-
-	// Step 1: Inject all registered global options
 	for _, globalOpt := range registeredGlobalOptions {
 		pathOptions[globalOpt.optName] = globalOpt
 	}
-
-	// Step 2: Add command-specific options (overwrites globals if names collide)
 	for _, option := range options {
 		pathOptions[option.optName] = option
 	}
-
 	return pathOptions
 }

--- a/sonic_data_client/show_client_types.go
+++ b/sonic_data_client/show_client_types.go
@@ -9,7 +9,7 @@ type ShowCmdOption struct {
 	description string     // will be used in help output
 	valueType   ValueType
 	enumValues  []string // valid only when valueType is EnumValue
-	hidden      bool     // true = exclude from help output
+	hidden      bool     // when true, exclude from help output
 }
 
 type OptionValue struct {
@@ -49,13 +49,10 @@ var (
 	)
 )
 
-// registeredGlobalOptions defines options that are automatically available to all CLI commands.
-// These options are injected into every command's option map by constructOptions.
-// Command-specific options with the same name will override these global options.
+// registeredGlobalOptions defines options that are automatically available to all show commands
 var registeredGlobalOptions = []ShowCmdOption{
 	showCmdOptionHelp,
 	showCmdOptionRedact,
-	// Add future global options here
 }
 
 const (

--- a/sonic_data_client/show_client_types.go
+++ b/sonic_data_client/show_client_types.go
@@ -9,6 +9,7 @@ type ShowCmdOption struct {
 	description string     // will be used in help output
 	valueType   ValueType
 	enumValues  []string // valid only when valueType is EnumValue
+	hidden      bool     // true = exclude from help output
 }
 
 type OptionValue struct {
@@ -38,7 +39,24 @@ var (
 		showCmdOptionHelpDesc,
 		BoolValue,
 	)
+
+	showCmdOptionRedact = HiddenOption(
+		NewShowCmdOption(
+			"redact",
+			"",
+			BoolValue,
+		),
+	)
 )
+
+// registeredGlobalOptions defines options that are automatically available to all CLI commands.
+// These options are injected into every command's option map by constructOptions.
+// Command-specific options with the same name will override these global options.
+var registeredGlobalOptions = []ShowCmdOption{
+	showCmdOptionHelp,
+	showCmdOptionRedact,
+	// Add future global options here
+}
 
 const (
 	StringValue      ValueType = 0
@@ -99,5 +117,11 @@ func RequiredOption(option ShowCmdOption) ShowCmdOption {
 
 func UnimplementedOption(option ShowCmdOption) ShowCmdOption {
 	option.optType = Unimplemented
+	return option
+}
+
+func HiddenOption(option ShowCmdOption) ShowCmdOption {
+	option.hidden = true
+	option.description = "(hidden)"
 	return option
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- Support global hidden options such as "redact". Global options mean that they are usable by any paths and don't need to be specifically added manually. Hidden means that they are not shown in the help description.
- Reboot cause paths are the only paths that make use of redact such that if redact is not set directly to false, we will redact the user field in each reboot cause json.

#### How I did it

Add redact global option + redact helper

#### (SHOW command specific) What sources are you using to fetch data?

N/A

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)



#### (Show command specific) Output of show CLI that is equivalent to API output

N/A -> show cli does not/has no reason for redaction.

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

```
gnmi_get -xpath_target SHOW -xpath reboot-cause -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "reboot-cause"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1759788382636395650
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "reboot-cause"
      >
    >
    val: <
      json_ietf_val: "{\"cause\":\"reboot\",\"comment\":\"N/A\",\"gen_time\":\"2025_10_03_21_12_41\",\"time\":\"Fri Oct  3 09:08:27 PM UTC 2025\",\"user\":\"[REDACTED]\"}"
    >
  >
>

gnmi_get -xpath_target SHOW -xpath reboot-cause/history -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "reboot-cause"
  >
  elem: <
    name: "history"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1759788393833992772
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "reboot-cause"
      >
      elem: <
        name: "history"
      >
    >
    val: <
      json_ietf_val: "{\"2025_09_05_16_52_37\":{\"cause\":\"Power Loss\",\"comment\":\"Unknown\",\"time\":\"N/A\",\"user\":\"[REDACTED]\"},\"2025_09_05_17_36_44\":{\"cause\":\"Power Loss\",\"comment\":\"Unknown\",\"time\":\"N/A\",\"user\":\"[REDACTED]\"},\"2025_09_05_17_56_58\":{\"cause\":\"Power Loss\",\"comment\":\"Unknown\",\"time\":\"N/A\",\"user\":\"[REDACTED]\"},\"2025_09_05_18_03_30\":{\"cause\":\"Power Loss\",\"comment\":\"Unknown\",\"time\":\"N/A\",\"user\":\"[REDACTED]\"},\"2025_09_08_18_06_01\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Mon Sep  8 06:01:53 PM UTC 2025\",\"user\":\"[REDACTED]\"},\"2025_09_08_18_21_44\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Mon Sep  8 06:16:22 PM UTC 2025\",\"user\":\"[REDACTED]\"},\"2025_09_30_17_48_05\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Sep 30 05:44:07 PM UTC 2025\",\"user\":\"[REDACTED]\"},\"2025_09_30_17_56_44\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Tue Sep 30 05:51:36 PM UTC 2025\",\"user\":\"[REDACTED]\"},\"2025_10_03_20_56_02\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Fri Oct  3 08:52:51 PM UTC 2025\",\"user\":\"[REDACTED]\"},\"2025_10_03_21_12_41\":{\"cause\":\"reboot\",\"comment\":\"N/A\",\"time\":\"Fri Oct  3 09:08:27 PM UTC 2025\",\"user\":\"[REDACTED]\"}}"
    >
  >
>

```

#### A picture of a cute animal (not mandatory but encouraged)

<img width="236" height="315" alt="image" src="https://github.com/user-attachments/assets/6e4ab6a4-ff58-4ce6-86fd-ddc3f67e2421" />

