### PR TITLE
Added show management-interface address command

### DIFF
--- a/gnmi_server/management_interface_address_cli_test.go
+++ b/gnmi_server/management_interface_address_cli_test.go
@@ -1,0 +1,167 @@
+package gnmi
+
+import (
+	"crypto/tls"
+	"fmt"
+	"testing"
+	"time"
+
+	"context"
+	"github.com/agiledragon/gomonkey/v2"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetManagementInterfaceAddress(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	expectedManagementInterface := `[{"Management IP address":"10.0.0.5/8","Management Network Default Gateway":"10.0.0.1"},{"Management IP address":"192.168.1.100/24","Management Network Default Gateway":"192.168.1.1"}]`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func() *gomonkey.Patches
+	}{
+		{
+			desc:       "query SHOW management-interface address success",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "management-interface" >
+				elem: <name: "address" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedManagementInterface),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"eth0|192.168.1.100/24": map[string]interface{}{
+							"gwaddr": "192.168.1.1",
+						},
+						"eth0|10.0.0.5/8": map[string]interface{}{
+							"gwaddr": "10.0.0.1",
+						},
+					}, nil
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW management-interface address with empty data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "management-interface" >
+				elem: <name: "address" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(`[]`),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{}, nil
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW management-interface address without gateway",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "management-interface" >
+				elem: <name: "address" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(`[{"Management IP address":"192.168.1.100/24","Management Network Default Gateway":""}]`),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"eth0|192.168.1.100/24": map[string]interface{}{},
+					}, nil
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW management-interface address with invalid key format",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "management-interface" >
+				elem: <name: "address" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(`[]`),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"eth0_invalid_key": map[string]interface{}{
+							"gwaddr": "192.168.1.1",
+						},
+					}, nil
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW management-interface address with database error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "management-interface" >
+				elem: <name: "address" >
+			`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(common.GetMapFromQueries, func(queries [][]string) (map[string]interface{}, error) {
+					return nil, fmt.Errorf("simulated database error")
+				})
+				return patches
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var patch *gomonkey.Patches
+		if test.testInit != nil {
+			patch = test.testInit()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+		if patch != nil {
+			patch.Reset()
+		}
+	}
+}

--- a/show_client/management_interface_address_cli.go
+++ b/show_client/management_interface_address_cli.go
@@ -1,0 +1,75 @@
+package show_client
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	natural "github.com/maruel/natural"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+// ManagementInterfaceAddress represents a single management interface address entry
+type ManagementInterfaceAddress struct {
+	ManagementIPAddress             string `json:"Management IP address"`
+	ManagementNetworkDefaultGateway string `json:"Management Network Default Gateway"`
+}
+
+const (
+	MgmtInterfaceTable = "MGMT_INTERFACE"
+)
+
+// getManagementInterfaceAddress retrieves management interface IP addresses and gateways
+func getManagementInterfaceAddress(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	// Query CONFIG_DB for MGMT_INTERFACE table
+	queries := [][]string{
+		{common.ConfigDb, MgmtInterfaceTable},
+	}
+
+	mgmtData, err := common.GetMapFromQueries(queries)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := make([]ManagementInterfaceAddress, 0)
+
+	// Process the management interface data
+	// The key format is typically: "eth0|10.0.0.1/24" where the IP is after |
+	// The value contains gateway information
+
+	// Get keys and sort them naturally (matches Python natsorted behavior)
+	keys := make([]string, 0, len(mgmtData))
+	for key := range mgmtData {
+		keys = append(keys, key)
+	}
+	sort.Sort(natural.StringSlice(keys))
+
+	for _, key := range keys {
+		// Parse the key to extract interface and IP address
+		// Format: "interface|ip_address"
+		keyParts := strings.Split(key, "|")
+		if len(keyParts) == 2 {
+			ipAddress := keyParts[1]
+
+			// Extract gateway from the value
+			defaultGateway := ""
+			if valueData, exists := mgmtData[key]; exists {
+				if valueMap, isMap := valueData.(map[string]interface{}); isMap {
+					if gwAddr, hasGw := valueMap["gwaddr"]; hasGw {
+						if gwStr, isString := gwAddr.(string); isString {
+							defaultGateway = gwStr
+						}
+					}
+				}
+			}
+
+			addresses = append(addresses, ManagementInterfaceAddress{
+				ManagementIPAddress:             ipAddress,
+				ManagementNetworkDefaultGateway: defaultGateway,
+			})
+		}
+	}
+
+	return json.Marshal(addresses)
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1131,4 +1131,14 @@ func init() {
 		0,
 		nil,
 	)
+
+	//SHOW/management-interface/address
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "management-interface", "address"},
+		getManagementInterfaceAddress,
+		"SHOW/management-interface/address[OPTIONS]: Show management interface parameters",
+		0,
+		0,
+		nil,
+	)
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

MS ADO: 37714109
#### Why I did it
Added gNMI getter for show management-interface address so client can fetch platform information via gNMI in JSON format.

#### How I did it
Added getManagementInterfaceAddress() function which calls CONFIG_DB|MGMT_INTERFACE table.

#### How to verify it
mellanox output:
```
admin@<machine>:~$ show management_interface address
Management IP address = 2a01:111:e*******a03:92bf/64
Management Network Default Gateway = 2a01:1******00::1
Management IP address = 10.3****91/24
Management Network Default Gateway = 10.*.**6.1
```

```
root@<machine>:/# gnmi_get -xpath_target SHOW -xpath management-interface/address -target_addr <machine-ip> -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "management-interface"
  >
  elem: <
    name: "address"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777288505581848735
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "management-interface"
      >
      elem: <
        name: "address"
      >
    >
    val: <
      json_ietf_val: "[{\"Management IP address\":\"10.15****07/23\",\"Management Network Default Gateway\":\"10.*****.1\"},{\"Management IP address\":\"2404:f80*******a96:16cf/52\",\"Management Network Default Gateway\":\"2404:******2000::1\"}]"
    >
  >
>
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

