### PR TITLE
added pcieinfo code

### DIFF
--- a/gnmi_server/platform_cli_test.go
+++ b/gnmi_server/platform_cli_test.go
@@ -6,6 +6,9 @@ package gnmi
 
 import (
 	"crypto/tls"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -503,6 +506,171 @@ func TestGetShowPlatformCurrent(t *testing.T) {
 			if tt.testInit != nil {
 				tt.testInit()
 			}
+
+			s := createServer(t, ServerPort)
+			go runServer(t, s)
+			defer s.ForceStop()
+
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+			conn, err := grpc.Dial(TargetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+			}
+			defer conn.Close()
+
+			gClient := pb.NewGNMIClient(conn)
+			ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, tt.pathTarget, tt.textPbPath, tt.wantRetCode, tt.wantRespVal, tt.valTest)
+		})
+	}
+}
+
+func TestGetShowPlatformPcieinfo(t *testing.T) {
+	showOutputFilename := "../testdata/PCIEINFO_SHOW.json"
+	checkOutputFilename := "../testdata/PCIEINFO_CHECK.json"
+	invalidOutputFilename := "../testdata/INVALID_JSON.txt"
+
+	showOutputBytes, err := os.ReadFile(showOutputFilename)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", showOutputFilename, err)
+	}
+	checkOutputBytes, err := os.ReadFile(checkOutputFilename)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", checkOutputFilename, err)
+	}
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func() *gomonkey.Patches
+	}{
+		{
+			desc:       "query SHOW platform pcieinfo",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: showOutputBytes,
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
+					if strings.Contains(cmd, "get_pcie_device") {
+						return string(showOutputBytes), nil
+					}
+					return "", fmt.Errorf("unexpected command: %s", cmd)
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform pcieinfo check",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" key: { key: "check" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: checkOutputBytes,
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
+					if strings.Contains(cmd, "get_pcie_check") {
+						return string(checkOutputBytes), nil
+					}
+					return "", fmt.Errorf("unexpected command: %s", cmd)
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform pcieinfo invalid JSON output",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" >
+			`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				return MockNSEnterOutput(t, invalidOutputFilename)
+			},
+		},
+		{
+			desc:       "query SHOW platform pcieinfo host command error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" >
+			`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
+					return "", fmt.Errorf("simulated command failure")
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform pcieinfo with verbose flag",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" key: { key: "verbose" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: showOutputBytes,
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
+					if strings.Contains(cmd, "get_pcie_device") {
+						return string(showOutputBytes), nil
+					}
+					return "", fmt.Errorf("unexpected command: %s", cmd)
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform pcieinfo check with verbose flag",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "pcieinfo" key: { key: "check" value: "true" } key: { key: "verbose" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: checkOutputBytes,
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
+					if strings.Contains(cmd, "get_pcie_check") {
+						return string(checkOutputBytes), nil
+					}
+					return "", fmt.Errorf("unexpected command: %s", cmd)
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var patches *gomonkey.Patches
+			if tt.testInit != nil {
+				patches = tt.testInit()
+			}
+			defer func() {
+				if patches != nil {
+					patches.Reset()
+				}
+			}()
 
 			s := createServer(t, ServerPort)
 			go runServer(t, s)

--- a/gnmi_server/platform_cli_test.go
+++ b/gnmi_server/platform_cli_test.go
@@ -532,6 +532,7 @@ func TestGetShowPlatformCurrent(t *testing.T) {
 func TestGetShowPlatformPcieinfo(t *testing.T) {
 	showOutputFilename := "../testdata/PCIEINFO_SHOW.json"
 	checkOutputFilename := "../testdata/PCIEINFO_CHECK.json"
+	checkRawOutputFilename := "../testdata/PCIEINFO_CHECK_RAW.json"
 	invalidOutputFilename := "../testdata/INVALID_JSON.txt"
 
 	showOutputBytes, err := os.ReadFile(showOutputFilename)
@@ -541,6 +542,10 @@ func TestGetShowPlatformPcieinfo(t *testing.T) {
 	checkOutputBytes, err := os.ReadFile(checkOutputFilename)
 	if err != nil {
 		t.Fatalf("read file %v err: %v", checkOutputFilename, err)
+	}
+	checkRawOutputBytes, err := os.ReadFile(checkRawOutputFilename)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", checkRawOutputFilename, err)
 	}
 
 	tests := []struct {
@@ -584,7 +589,9 @@ func TestGetShowPlatformPcieinfo(t *testing.T) {
 			testInit: func() *gomonkey.Patches {
 				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					if strings.Contains(cmd, "get_pcie_check") {
-						return string(checkOutputBytes), nil
+						// Return raw output with extra fields (bus/dev/fn/id) as a real platform would.
+						// The handler must strip them and return only name/result.
+						return string(checkRawOutputBytes), nil
 					}
 					return "", fmt.Errorf("unexpected command: %s", cmd)
 				})
@@ -652,7 +659,7 @@ func TestGetShowPlatformPcieinfo(t *testing.T) {
 			testInit: func() *gomonkey.Patches {
 				return gomonkey.ApplyFunc(sccommon.GetDataFromHostCommand, func(cmd string) (string, error) {
 					if strings.Contains(cmd, "get_pcie_check") {
-						return string(checkOutputBytes), nil
+						return string(checkRawOutputBytes), nil
 					}
 					return "", fmt.Errorf("unexpected command: %s", cmd)
 				})

--- a/show_client/common/host.go
+++ b/show_client/common/host.go
@@ -251,6 +251,15 @@ func GetPlatformConfigFilePath() string {
 	return ""
 }
 
+func GetPlatformPath() string {
+	platform := GetPlatform()
+	if platform != "" {
+		return filepath.Join(HostDevicePath, platform)
+	}
+
+	return ContainerPlatformPath
+}
+
 func IsExpectedValue(val string, expectedVal string) bool {
 	if strings.TrimSpace(val) == expectedVal {
 		return true

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -393,3 +393,29 @@ func getPlatformCurrent(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 		}
 	})
 }
+
+func getPlatformPcieinfo(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	apiCall := "get_pcie_device"
+	if checkOpt, ok := options["check"].Bool(); ok && checkOpt {
+		apiCall = "get_pcie_check"
+	}
+
+	pyCmd := fmt.Sprintf(`python3 -c 'import importlib.util, json; from sonic_py_common import device_info; platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs(); spec = importlib.util.find_spec("sonic_platform.pcie"); cls = __import__("sonic_platform.pcie", fromlist=["Pcie"]).Pcie if spec is not None else __import__("sonic_platform_base.sonic_pcie.pcie_common", fromlist=["PcieUtil"]).PcieUtil; pcie = cls(platform_path); print(json.dumps(getattr(pcie, %q)()))'`, apiCall)
+
+	output, err := common.GetDataFromHostCommand(pyCmd)
+	if err != nil {
+		log.Errorf("Failed to get PCIe info from host command: %v", err)
+		return nil, err
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return []byte("[]"), nil
+	}
+
+	if !json.Valid([]byte(output)) {
+		return nil, fmt.Errorf("invalid JSON output from PCIe host command")
+	}
+
+	return []byte(output), nil
+}

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -93,6 +93,11 @@ type CurrentInfo struct {
 	Timestamp  string `json:"timestamp"`
 }
 
+type pcieCheckResult struct {
+	Name   string `json:"name"`
+	Result string `json:"result"`
+}
+
 // getPlatformSummary implements the "show platform summary" command
 func getPlatformSummary(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	// Get version info to extract ASIC type
@@ -395,17 +400,32 @@ func getPlatformCurrent(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 }
 
 func getPlatformPcieinfo(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
-	apiCall := "get_pcie_device"
+	apiCall := "pcie.get_pcie_device()"
 	if checkOpt, ok := options["check"].Bool(); ok && checkOpt {
-		apiCall = "get_pcie_check"
+		apiCall = "pcie.get_pcie_check()"
 	}
 
-	pyCmd := fmt.Sprintf(`python3 -c 'import importlib.util, json; from sonic_py_common import device_info; platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs(); spec = importlib.util.find_spec("sonic_platform.pcie"); cls = __import__("sonic_platform.pcie", fromlist=["Pcie"]).Pcie if spec is not None else __import__("sonic_platform_base.sonic_pcie.pcie_common", fromlist=["PcieUtil"]).PcieUtil; pcie = cls(platform_path); print(json.dumps(getattr(pcie, %q)()))'`, apiCall)
+	platformPath := common.GetPlatformPath()
+
+	pyScript := fmt.Sprintf(`
+import json
+platform_path = %s
+try:
+    from sonic_platform.pcie import Pcie
+    pcie = Pcie(platform_path)
+except ImportError:
+    from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+    pcie = PcieUtil(platform_path)
+print(json.dumps(%s))
+`, strconv.Quote(platformPath), apiCall)
+	escaped := strings.ReplaceAll(pyScript, "'", `'\''`)
+	pyCmd := fmt.Sprintf("python3 -c '%s'", escaped)
 
 	output, err := common.GetDataFromHostCommand(pyCmd)
 	if err != nil {
-		log.Errorf("Failed to get PCIe info from host command: %v", err)
-		return nil, err
+		trimmedOutput := strings.TrimSpace(output)
+		log.Errorf("Failed to get PCIe info from host command: %v, output: %s", err, trimmedOutput)
+		return nil, fmt.Errorf("failed to get PCIe info from host command: %w, output: %s", err, trimmedOutput)
 	}
 
 	output = strings.TrimSpace(output)
@@ -414,7 +434,37 @@ func getPlatformPcieinfo(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error
 	}
 
 	if !json.Valid([]byte(output)) {
-		return nil, fmt.Errorf("invalid JSON output from PCIe host command")
+		lines := strings.Split(output, "\n")
+		for i := len(lines) - 1; i >= 0; i-- {
+			candidate := strings.TrimSpace(lines[i])
+			if candidate != "" && json.Valid([]byte(candidate)) {
+				output = candidate
+				break
+			}
+		}
+		if !json.Valid([]byte(output)) {
+			return nil, fmt.Errorf("invalid JSON output from PCIe host command: %s", strings.TrimSpace(output))
+		}
+	}
+
+	if checkOpt, ok := options["check"].Bool(); ok && checkOpt {
+		var normalized []pcieCheckResult
+		if err := json.Unmarshal([]byte(output), &normalized); err != nil {
+			return nil, fmt.Errorf("failed to parse PCIe check output: %w", err)
+		}
+
+		for i := range normalized {
+			if normalized[i].Result != "Passed" {
+				normalized[i].Result = "Failed"
+			}
+		}
+
+		normalizedBytes, err := json.Marshal(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode PCIe check output: %w", err)
+		}
+
+		return normalizedBytes, nil
 	}
 
 	return []byte(output), nil

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -35,6 +35,7 @@ const (
 	showCmdOptionLinesDesc             = "[lines=INTEGER] Number of lines to show (default: 10)"
 	showCmdOptionPsuIndexDesc          = "[index=INTEGER] Display a specific PSU by index"
 	showCmdOptionHistoryDesc           = "[history=true] Display historical PFC statistics"
+	showCmdOptionCheckDesc             = "[check=true] Validate PCIe devices against expected list"
 )
 
 // Option keys
@@ -231,6 +232,12 @@ var (
 	showCmdOptionHistory = sdc.NewShowCmdOption(
 		"history",
 		showCmdOptionHistoryDesc,
+		sdc.BoolValue,
+	)
+
+	showCmdOptionCheck = sdc.NewShowCmdOption(
+		"check",
+		showCmdOptionCheckDesc,
 		sdc.BoolValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1068,6 +1068,18 @@ func init() {
 		nil,
 	)
 
+	// SHOW/platform/pcieinfo
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "platform", "pcieinfo"},
+		getPlatformPcieinfo,
+		"SHOW/platform/pcieinfo[OPTIONS]: Show device PCIe information",
+		0,
+		0,
+		nil,
+		showCmdOptionCheck,
+		showCmdOptionVerbose,
+	)
+
 	// SHOW/pfc
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "pfc", "counters"},

--- a/testdata/PCIEINFO_CHECK.json
+++ b/testdata/PCIEINFO_CHECK.json
@@ -1,0 +1,2 @@
+[{"name":"PCI Device A","result":"Passed"},{"name":"PCI Device B","result":"Failed"}]
+

--- a/testdata/PCIEINFO_CHECK_RAW.json
+++ b/testdata/PCIEINFO_CHECK_RAW.json
@@ -1,0 +1,2 @@
+[{"bus":"03","dev":"00","fn":"0","id":"1db6","name":"PCI Device A","result":"Passed"},{"bus":"03","dev":"01","fn":"0","id":"1db7","name":"PCI Device B","result":"Failed"}]
+

--- a/testdata/PCIEINFO_SHOW.json
+++ b/testdata/PCIEINFO_SHOW.json
@@ -1,0 +1,2 @@
+[{"bus":"03","dev":"00","fn":"0","id":"1db6","name":"Mellanox Device"}]
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Added gNMI getter for show platform pcieinfo so client can fetchdevice PCIe information via gNMI in JSON format.

#### How I did it

Runs host-side Python through existing helper (common.GetDataFromHostCommand).
Uses platform API loading logic aligned with sonic-utilities behavior:
tries sonic_platform.pcie.Pcie
falls back to sonic_platform_base.sonic_pcie.pcie_common.PcieUtil
Supports:
default mode: get_pcie_device()
check mode: get_pcie_check() when check=true
Returns JSON directly (validated with json.Valid)

#### (SHOW command specific) What sources are you using to fetch data?

Host side python cmd

#### How to verify it (Please provide snapshot of diff coverage from CI pipeline)

#### (Show command specific) Output of show CLI that is equivalent to API output

```
admin@bjw2-can-4600c-6:~$ show platform pcieinfo
==============================Display PCIe Device===============================
bus:dev.fn 00:00.0 - dev_id=0x6f00, Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2 (rev 03)
bus:dev.fn 00:01.0 - dev_id=0x6f02, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)
bus:dev.fn 00:01.1 - dev_id=0x6f03, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)
bus:dev.fn 00:02.0 - dev_id=0x6f04, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)
bus:dev.fn 00:02.2 - dev_id=0x6f06, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)
bus:dev.fn 00:03.0 - dev_id=0x6f08, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)
bus:dev.fn 00:03.1 - dev_id=0x6f09, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)
bus:dev.fn 00:03.2 - dev_id=0x6f0a, PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)
bus:dev.fn 00:05.0 - dev_id=0x6f28, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Map/VTd_Misc/System Management (rev 03)
bus:dev.fn 00:05.1 - dev_id=0x6f29, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO Hot Plug (rev 03)
bus:dev.fn 00:05.2 - dev_id=0x6f2a, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO RAS/Control Status/Global Errors (rev 03)
bus:dev.fn 00:05.4 - dev_id=0x6f2c, PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev 03)
bus:dev.fn 00:14.0 - dev_id=0x8c31, USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB xHCI (rev 05)
bus:dev.fn 00:1c.0 - dev_id=0x8c10, PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #1 (rev d5)
bus:dev.fn 00:1c.7 - dev_id=0x8c1e, PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #8 (rev d5)
bus:dev.fn 00:1d.0 - dev_id=0x8c26, USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB EHCI #1 (rev 05)
bus:dev.fn 00:1f.0 - dev_id=0x8c54, ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard SKU LPC Controller (rev 05)
bus:dev.fn 00:1f.2 - dev_id=0x8c02, SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode] (rev 05)
bus:dev.fn 00:1f.3 - dev_id=0x8c22, SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller (rev 05)
bus:dev.fn 03:00.0 - dev_id=0x6f50, System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 0
bus:dev.fn 03:00.1 - dev_id=0x6f51, System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 1
bus:dev.fn 03:00.2 - dev_id=0x6f52, System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 2
bus:dev.fn 03:00.3 - dev_id=0x6f53, System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 3
bus:dev.fn 07:00.0 - dev_id=0xcf70, Ethernet controller: Mellanox Technologies Spectrum-3
bus:dev.fn 09:00.0 - dev_id=0x1533, Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
bus:dev.fn ff:0b.0 - dev_id=0x6f81, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)
bus:dev.fn ff:0b.1 - dev_id=0x6f36, Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)
bus:dev.fn ff:0b.2 - dev_id=0x6f37, Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)
bus:dev.fn ff:0b.3 - dev_id=0x6f76, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link Debug (rev 03)
bus:dev.fn ff:0c.0 - dev_id=0x6fe0, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0c.1 - dev_id=0x6fe1, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0c.2 - dev_id=0x6fe2, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0c.3 - dev_id=0x6fe3, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0f.0 - dev_id=0x6ff8, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0f.4 - dev_id=0x6ffc, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0f.5 - dev_id=0x6ffd, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:0f.6 - dev_id=0x6ffe, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)
bus:dev.fn ff:10.0 - dev_id=0x6f1d, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)
bus:dev.fn ff:10.1 - dev_id=0x6f34, Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)
bus:dev.fn ff:10.5 - dev_id=0x6f1e, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)
bus:dev.fn ff:10.6 - dev_id=0x6f7d, Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)
bus:dev.fn ff:10.7 - dev_id=0x6f1f, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)
bus:dev.fn ff:12.0 - dev_id=0x6fa0, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)
bus:dev.fn ff:12.1 - dev_id=0x6f30, Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)
bus:dev.fn ff:13.0 - dev_id=0x6fa8, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)
bus:dev.fn ff:13.1 - dev_id=0x6f71, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)
bus:dev.fn ff:13.2 - dev_id=0x6faa, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)
bus:dev.fn ff:13.3 - dev_id=0x6fab, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)
bus:dev.fn ff:13.4 - dev_id=0x6fac, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)
bus:dev.fn ff:13.5 - dev_id=0x6fad, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)
bus:dev.fn ff:13.6 - dev_id=0x6fae, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Broadcast (rev 03)
bus:dev.fn ff:13.7 - dev_id=0x6faf, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Global Broadcast (rev 03)
bus:dev.fn ff:14.0 - dev_id=0x6fb0, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Thermal Control (rev 03)
bus:dev.fn ff:14.1 - dev_id=0x6fb1, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Thermal Control (rev 03)
bus:dev.fn ff:14.2 - dev_id=0x6fb2, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Error (rev 03)
bus:dev.fn ff:14.3 - dev_id=0x6fb3, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Error (rev 03)
bus:dev.fn ff:14.4 - dev_id=0x6fbc, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)
bus:dev.fn ff:14.5 - dev_id=0x6fbd, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)
bus:dev.fn ff:14.6 - dev_id=0x6fbe, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)
bus:dev.fn ff:14.7 - dev_id=0x6fbf, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)
bus:dev.fn ff:15.0 - dev_id=0x6fb4, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Thermal Control (rev 03)
bus:dev.fn ff:15.1 - dev_id=0x6fb5, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Thermal Control (rev 03)
bus:dev.fn ff:15.2 - dev_id=0x6fb6, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Error (rev 03)
bus:dev.fn ff:15.3 - dev_id=0x6fb7, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Error (rev 03)
bus:dev.fn ff:1e.0 - dev_id=0x6f98, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1e.1 - dev_id=0x6f99, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1e.2 - dev_id=0x6f9a, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1e.3 - dev_id=0x6fc0, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1e.4 - dev_id=0x6f9c, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1f.0 - dev_id=0x6f88, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
bus:dev.fn ff:1f.2 - dev_id=0x6f8a, System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)
admin@bjw2-can-4600c-6:~$ show platform pcieinfo --check
===============================PCIe Device Check================================
PCI Device:  Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2 (rev 03) ------- [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)  [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)  [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)  [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)  [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)  [Passed]
PCI Device:  PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Map/VTd_Misc/System Management (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO Hot Plug (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO RAS/Control Status/Global Errors (rev 03)  [Passed]
PCI Device:  PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev 03) ----------- [Passed]
PCI Device:  USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB xHCI (rev 05) ---- [Passed]
PCI Device:  PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #1 (rev d5)  [Passed]
PCI Device:  PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #8 (rev d5)  [Passed]
PCI Device:  USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB EHCI #1 (rev 05) - [Passed]
PCI Device:  ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard SKU LPC Controller (rev 05)  [Passed]
PCI Device:  SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode] (rev 05)  [Passed]
PCI Device:  SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller (rev 05) ----- [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 0  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 1  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 2  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 3  [Passed]
PCI Device:  Ethernet controller: Mellanox Technologies Device cf70 ------------------------------------- [Passed]
PCI Device:  Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03) ------------ [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)  [Passed]
PCI Device:  Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)  [Passed]
PCI Device:  Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link Debug (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)  [Passed]
PCI Device:  Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03) - [Passed]
PCI Device:  Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03) - [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)  [Passed]
PCI Device:  Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Broadcast (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Global Broadcast (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Thermal Control (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Thermal Control (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Error (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Error (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Thermal Control (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Thermal Control (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Error (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Error (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCI Device:  System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)  [Passed]
PCIe Device Checking All Test ----------->>> PASSED
```

#### Manual test output of API on device (Please provide output from device that you have tested your changes on)

Mellanox results below, Arista added in comments
```
root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/pcieinfo -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "pcieinfo"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777561927521146415
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "pcieinfo"
      >
    >
    val: <
      json_ietf_val: "[{\"name\": \"Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2 (rev 03)\", \"bus\": \"00\", \"dev\": \"00\", \"fn\": \"0\", \"id\": \"6f00\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)\", \"bus\": \"00\", \"dev\": \"01\", \"fn\": \"0\", \"id\": \"6f02\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)\", \"bus\": \"00\", \"dev\": \"01\", \"fn\": \"1\", \"id\": \"6f03\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)\", \"bus\": \"00\", \"dev\": \"02\", \"fn\": \"0\", \"id\": \"6f04\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)\", \"bus\": \"00\", \"dev\": \"02\", \"fn\": \"2\", \"id\": \"6f06\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)\", \"bus\": \"00\", \"dev\": \"03\", \"fn\": \"0\", \"id\": \"6f08\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)\", \"bus\": \"00\", \"dev\": \"03\", \"fn\": \"1\", \"id\": \"6f09\"}, {\"name\": \"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)\", \"bus\": \"00\", \"dev\": \"03\", \"fn\": \"2\", \"id\": \"6f0a\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Map/VTd_Misc/System Management (rev 03)\", \"bus\": \"00\", \"dev\": \"05\", \"fn\": \"0\", \"id\": \"6f28\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO Hot Plug (rev 03)\", \"bus\": \"00\", \"dev\": \"05\", \"fn\": \"1\", \"id\": \"6f29\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO RAS/Control Status/Global Errors (rev 03)\", \"bus\": \"00\", \"dev\": \"05\", \"fn\": \"2\", \"id\": \"6f2a\"}, {\"name\": \"PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev 03)\", \"bus\": \"00\", \"dev\": \"05\", \"fn\": \"4\", \"id\": \"6f2c\"}, {\"name\": \"USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB xHCI (rev 05)\", \"bus\": \"00\", \"dev\": \"14\", \"fn\": \"0\", \"id\": \"8c31\"}, {\"name\": \"PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #1 (rev d5)\", \"bus\": \"00\", \"dev\": \"1c\", \"fn\": \"0\", \"id\": \"8c10\"}, {\"name\": \"PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #8 (rev d5)\", \"bus\": \"00\", \"dev\": \"1c\", \"fn\": \"7\", \"id\": \"8c1e\"}, {\"name\": \"USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB EHCI #1 (rev 05)\", \"bus\": \"00\", \"dev\": \"1d\", \"fn\": \"0\", \"id\": \"8c26\"}, {\"name\": \"ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard SKU LPC Controller (rev 05)\", \"bus\": \"00\", \"dev\": \"1f\", \"fn\": \"0\", \"id\": \"8c54\"}, {\"name\": \"SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode] (rev 05)\", \"bus\": \"00\", \"dev\": \"1f\", \"fn\": \"2\", \"id\": \"8c02\"}, {\"name\": \"SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller (rev 05)\", \"bus\": \"00\", \"dev\": \"1f\", \"fn\": \"3\", \"id\": \"8c22\"}, {\"name\": \"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 0\", \"bus\": \"03\", \"dev\": \"00\", \"fn\": \"0\", \"id\": \"6f50\"}, {\"name\": \"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 1\", \"bus\": \"03\", \"dev\": \"00\", \"fn\": \"1\", \"id\": \"6f51\"}, {\"name\": \"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 2\", \"bus\": \"03\", \"dev\": \"00\", \"fn\": \"2\", \"id\": \"6f52\"}, {\"name\": \"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 3\", \"bus\": \"03\", \"dev\": \"00\", \"fn\": \"3\", \"id\": \"6f53\"}, {\"name\": \"Ethernet controller: Mellanox Technologies Spectrum-3\", \"bus\": \"07\", \"dev\": \"00\", \"fn\": \"0\", \"id\": \"cf70\"}, {\"name\": \"Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)\", \"bus\": \"09\", \"dev\": \"00\", \"fn\": \"0\", \"id\": \"1533\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\", \"bus\": \"ff\", \"dev\": \"0b\", \"fn\": \"0\", \"id\": \"6f81\"}, {\"name\": \"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\", \"bus\": \"ff\", \"dev\": \"0b\", \"fn\": \"1\", \"id\": \"6f36\"}, {\"name\": \"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\", \"bus\": \"ff\", \"dev\": \"0b\", \"fn\": \"2\", \"id\": \"6f37\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link Debug (rev 03)\", \"bus\": \"ff\", \"dev\": \"0b\", \"fn\": \"3\", \"id\": \"6f76\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0c\", \"fn\": \"0\", \"id\": \"6fe0\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0c\", \"fn\": \"1\", \"id\": \"6fe1\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0c\", \"fn\": \"2\", \"id\": \"6fe2\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0c\", \"fn\": \"3\", \"id\": \"6fe3\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0f\", \"fn\": \"0\", \"id\": \"6ff8\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0f\", \"fn\": \"4\", \"id\": \"6ffc\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0f\", \"fn\": \"5\", \"id\": \"6ffd\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"0f\", \"fn\": \"6\", \"id\": \"6ffe\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"10\", \"fn\": \"0\", \"id\": \"6f1d\"}, {\"name\": \"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)\", \"bus\": \"ff\", \"dev\": \"10\", \"fn\": \"1\", \"id\": \"6f34\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\", \"bus\": \"ff\", \"dev\": \"10\", \"fn\": \"5\", \"id\": \"6f1e\"}, {\"name\": \"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\", \"bus\": \"ff\", \"dev\": \"10\", \"fn\": \"6\", \"id\": \"6f7d\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\", \"bus\": \"ff\", \"dev\": \"10\", \"fn\": \"7\", \"id\": \"6f1f\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)\", \"bus\": \"ff\", \"dev\": \"12\", \"fn\": \"0\", \"id\": \"6fa0\"}, {\"name\": \"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)\", \"bus\": \"ff\", \"dev\": \"12\", \"fn\": \"1\", \"id\": \"6f30\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"0\", \"id\": \"6fa8\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"1\", \"id\": \"6f71\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"2\", \"id\": \"6faa\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"3\", \"id\": \"6fab\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"4\", \"id\": \"6fac\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"5\", \"id\": \"6fad\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Broadcast (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"6\", \"id\": \"6fae\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Global Broadcast (rev 03)\", \"bus\": \"ff\", \"dev\": \"13\", \"fn\": \"7\", \"id\": \"6faf\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Thermal Control (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"0\", \"id\": \"6fb0\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Thermal Control (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"1\", \"id\": \"6fb1\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Error (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"2\", \"id\": \"6fb2\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Error (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"3\", \"id\": \"6fb3\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"4\", \"id\": \"6fbc\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"5\", \"id\": \"6fbd\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"6\", \"id\": \"6fbe\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\", \"bus\": \"ff\", \"dev\": \"14\", \"fn\": \"7\", \"id\": \"6fbf\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Thermal Control (rev 03)\", \"bus\": \"ff\", \"dev\": \"15\", \"fn\": \"0\", \"id\": \"6fb4\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Thermal Control (rev 03)\", \"bus\": \"ff\", \"dev\": \"15\", \"fn\": \"1\", \"id\": \"6fb5\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Error (rev 03)\", \"bus\": \"ff\", \"dev\": \"15\", \"fn\": \"2\", \"id\": \"6fb6\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Error (rev 03)\", \"bus\": \"ff\", \"dev\": \"15\", \"fn\": \"3\", \"id\": \"6fb7\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1e\", \"fn\": \"0\", \"id\": \"6f98\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1e\", \"fn\": \"1\", \"id\": \"6f99\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1e\", \"fn\": \"2\", \"id\": \"6f9a\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1e\", \"fn\": \"3\", \"id\": \"6fc0\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1e\", \"fn\": \"4\", \"id\": \"6f9c\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1f\", \"fn\": \"0\", \"id\": \"6f88\"}, {\"name\": \"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\", \"bus\": \"ff\", \"dev\": \"1f\", \"fn\": \"2\", \"id\": \"6f8a\"}]"
    >
  >
>

root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/pcieinfo[check=True] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "pcieinfo"
    key: <
      key: "check"
      value: "True"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777561944940716198
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "pcieinfo"
        key: <
          key: "check"
          value: "True"
        >
      >
    >
    val: <
      json_ietf_val: "[{\"name\":\"Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 1 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 2 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI Express Root Port 3 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Map/VTd_Misc/System Management (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO Hot Plug (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D IIO RAS/Control Status/Global Errors (rev 03)\",\"result\":\"Passed\"},{\"name\":\"PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev 03)\",\"result\":\"Passed\"},{\"name\":\"USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB xHCI (rev 05)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #1 (rev d5)\",\"result\":\"Passed\"},{\"name\":\"PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express Root Port #8 (rev d5)\",\"result\":\"Passed\"},{\"name\":\"USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB EHCI #1 (rev 05)\",\"result\":\"Passed\"},{\"name\":\"ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard SKU LPC Controller (rev 05)\",\"result\":\"Passed\"},{\"name\":\"SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode] (rev 05)\",\"result\":\"Passed\"},{\"name\":\"SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller (rev 05)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 0\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 1\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 2\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology Register DMA Channel 3\",\"result\":\"Passed\"},{\"name\":\"Ethernet controller: Mellanox Technologies Device cf70\",\"result\":\"Passed\"},{\"name\":\"Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link 0/1 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R3 QPI Link Debug (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D R2PCIe Agent (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\",\"result\":\"Passed\"},{\"name\":\"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Ubox (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Home Agent 0 (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel Target Address Decoder (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Broadcast (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Global Broadcast (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Thermal Control (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Thermal Control (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 0 Error (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 1 Error (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DDRIO Channel 0/1 Interface (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Thermal Control (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Thermal Control (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 2 Error (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Memory Controller 0 - Channel 3 Error (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"},{\"name\":\"System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Power Control Unit (rev 03)\",\"result\":\"Passed\"}]"
    >
  >
>
```

#### A picture of a cute animal (not mandatory but encouraged)