### PR TITLE
Onboard show platform ssdhealth command.

### DIFF
--- a/gnmi_server/platform_cli_test.go
+++ b/gnmi_server/platform_cli_test.go
@@ -2,10 +2,11 @@ package gnmi
 
 // platform_cli_test.go
 
-// Tests SHOW platform summary and psustatus
+// Tests SHOW platform summary, psustatus, fan, temperature, voltage, current, ssdhealth
 
 import (
 	"crypto/tls"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	sccommon "github.com/sonic-net/sonic-gnmi/show_client/common"
+	"github.com/sonic-net/sonic-gnmi/show_client/helpers"
 )
 
 func TestGetShowPlatformSummary(t *testing.T) {
@@ -503,6 +505,349 @@ func TestGetShowPlatformCurrent(t *testing.T) {
 			if tt.testInit != nil {
 				tt.testInit()
 			}
+
+			s := createServer(t, ServerPort)
+			go runServer(t, s)
+			defer s.ForceStop()
+
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+			conn, err := grpc.Dial(TargetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+			}
+			defer conn.Close()
+
+			gClient := pb.NewGNMIClient(conn)
+			ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, tt.pathTarget, tt.textPbPath, tt.wantRetCode, tt.wantRespVal, tt.valTest)
+		})
+	}
+}
+
+func TestGetShowPlatformSsdhealth(t *testing.T) {
+	// Mock SsdInfo values — matches helpers.SsdInfo struct
+	nvmeSsdInfo := &helpers.SsdInfo{
+		Model:        "SAMSUNG MZQLB960HAJR-00007",
+		Firmware:     "EDA5602Q",
+		Serial:       "S439NA0M900123",
+		Health:       "98",
+		Temperature:  "33",
+		VendorOutput: "Extended SMART info",
+	}
+	sataSsdInfo := &helpers.SsdInfo{
+		Model:        "InnoDisk Corp. - mSATA 3IE3",
+		Firmware:     "S16425cG",
+		Serial:       "BCA11712190600081",
+		Health:       "85",
+		Temperature:  "43",
+		VendorOutput: "",
+	}
+	nonNumericSsdInfo := &helpers.SsdInfo{
+		Model:        "SAMSUNG MZQLB960HAJR-00007",
+		Firmware:     "EDA5602Q",
+		Serial:       "S439NA0M900123",
+		Health:       "N/A",
+		Temperature:  "N/A",
+		VendorOutput: "",
+	}
+
+	// Expected outputs match SsdHealthInfo struct with omitempty:
+	//   default: disk_type, device_model, health, temperature
+	//   verbose: + firmware, serial
+	//   vendor:  + vendor_output (only when non-empty)
+	expectedNVMeDefault := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","health":"98%","temperature":"33C"}`
+	expectedNVMeVerbose := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","firmware":"EDA5602Q","serial":"S439NA0M900123","health":"98%","temperature":"33C"}`
+	expectedNVMeVendor := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","health":"98%","temperature":"33C","vendor_output":"Extended SMART info"}`
+	expectedNVMeVerboseVendor := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","firmware":"EDA5602Q","serial":"S439NA0M900123","health":"98%","temperature":"33C","vendor_output":"Extended SMART info"}`
+	expectedSATADefault := `{"disk_type":"SATA","device_model":"InnoDisk Corp. - mSATA 3IE3","health":"85%","temperature":"43C"}`
+	expectedSATAVerbose := `{"disk_type":"SATA","device_model":"InnoDisk Corp. - mSATA 3IE3","firmware":"S16425cG","serial":"BCA11712190600081","health":"85%","temperature":"43C"}`
+	expectedSATAVendor := `{"disk_type":"SATA","device_model":"InnoDisk Corp. - mSATA 3IE3","health":"85%","temperature":"43C"}`
+	expectedNotDetected := `{"message":"SSD not detected"}`
+	expectedPlatformJson := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","health":"98%","temperature":"33C"}`
+	expectedNonNumeric := `{"disk_type":"NVME","device_model":"SAMSUNG MZQLB960HAJR-00007","health":"N/A","temperature":"N/A"}`
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func() *gomonkey.Patches
+	}{
+		{
+			desc:       "query SHOW platform ssdhealth NVMe default (no options)",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNVMeDefault),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nvmeSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth NVMe verbose",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" key: { key: "verbose" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNVMeVerbose),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nvmeSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth NVMe vendor",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" key: { key: "vendor" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNVMeVendor),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nvmeSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth NVMe verbose+vendor",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" key: { key: "verbose" value: "true" } key: { key: "vendor" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNVMeVerboseVendor),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nvmeSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth SATA disk",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedSATADefault),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return sataSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/sda", "sata"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth SSD not detected",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNotDetected),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nil, fmt.Errorf("SsdUtil import failed")
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/sda", "sata"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth device from platform.json",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedPlatformJson),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nvmeSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"chassis": map[string]interface{}{
+							"disk": map[string]interface{}{
+								"device": "/dev/nvme0n1",
+							},
+						},
+					}, nil
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth SATA verbose",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" key: { key: "verbose" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedSATAVerbose),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return sataSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/sda", "sata"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth SATA vendor (empty vendor_output omitted)",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" key: { key: "vendor" value: "true" } >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedSATAVendor),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return sataSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/sda", "sata"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+		{
+			desc:       "query SHOW platform ssdhealth non-numeric health and temperature",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "ssdhealth" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedNonNumeric),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.NewPatches()
+				patches.ApplyFunc(helpers.ImportSsdApi, func(device string) (*helpers.SsdInfo, error) {
+					return nonNumericSsdInfo, nil
+				})
+				patches.ApplyFunc(helpers.GetDefaultDisk, func() (string, string) {
+					return "/dev/nvme0n1", "nvme"
+				})
+				patches.ApplyFunc(sccommon.GetPlatformJsonData, func() (map[string]interface{}, error) {
+					return nil, fmt.Errorf("not found")
+				})
+				return patches
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var patches *gomonkey.Patches
+			if tt.testInit != nil {
+				patches = tt.testInit()
+			}
+			defer func() {
+				if patches != nil {
+					patches.Reset()
+				}
+			}()
 
 			s := createServer(t, ServerPort)
 			go runServer(t, s)

--- a/show_client/common/file.go
+++ b/show_client/common/file.go
@@ -81,6 +81,8 @@ func GetMapFromFile(filePath string) (map[string]interface{}, error) {
 	return result, nil
 }
 
+// DirExists checks whether a directory exists at the given path.
+// Matches Python: os.path.isdir(path)
 func DirExists(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -118,4 +120,25 @@ func ReadConfKey(filePath string, key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// GetNestedString traverses a nested map using the given keys and returns the final value as a string.
+// Equivalent to Python: data.get(k1, {}).get(k2, {}).get(k3, None)
+// Returns empty string if any key is missing or the final value is not a string.
+func GetNestedString(data map[string]interface{}, keys ...string) string {
+	current := data
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			if val, ok := current[key].(string); ok {
+				return val
+			}
+			return ""
+		}
+		next, ok := current[key].(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
 }

--- a/show_client/common/host.go
+++ b/show_client/common/host.go
@@ -17,6 +17,7 @@ const (
 	asicConfFilename      = "asic.conf"
 	ContainerPlatformPath = "/usr/share/sonic/platform"
 	platformEnvConfFile   = "platform_env.conf"
+	PlatformJsonFile      = "platform.json"
 	serial                = "serial"
 	model                 = "model"
 	revision              = "revision"
@@ -283,4 +284,34 @@ func IsDisaggregatedChassis() bool {
 func IsSimxPlatform() bool {
 	platformName := GetPlatform()
 	return platformName != "" && strings.Contains(strings.ToLower(platformName), "simx")
+}
+
+// GetPlatformJsonData retrieves the data from platform.json file.
+func GetPlatformJsonData() (map[string]interface{}, error) {
+	// 1. Check container platform path
+	candidate := filepath.Join(ContainerPlatformPath, PlatformJsonFile)
+	if FileExists(candidate) {
+		return GetMapFromFile(candidate)
+	}
+
+	// 2. Check host device path with platform
+	platformName := GetPlatform()
+	if platformName != "" {
+		candidate = filepath.Join(HostDevicePath, platformName, PlatformJsonFile)
+		if FileExists(candidate) {
+			return GetMapFromFile(candidate)
+		}
+	}
+
+	return nil, fmt.Errorf("platform.json not found")
+}
+
+// GetPathsToPlatformAndHwskuDirsOnHost returns the paths to the device's platform
+// and hardware SKU directories on the host.
+func GetPathsToPlatformAndHwskuDirsOnHost() (string, string) {
+	platformName := GetPlatform()
+	platformPath := filepath.Join(HostDevicePath, platformName)
+	hwskuName := GetHwsku()
+	hwskuPath := filepath.Join(platformPath, hwskuName)
+	return platformPath, hwskuPath
 }

--- a/show_client/common/platform_apis.go
+++ b/show_client/common/platform_apis.go
@@ -1,0 +1,19 @@
+package common
+
+// SsdHealthPyScript is the Python script template that loads the platform-specific
+// or generic SsdUtil and retrieves SSD health information as JSON.
+// It expects two %s format parameters: platform path, then device path.
+var SsdHealthPyScript = `
+import sys, os, json
+try:
+    platform_plugins_path = os.path.join('%s', 'plugins')
+    sys.path.append(os.path.abspath(platform_plugins_path))
+    from ssd_util import SsdUtil
+except ImportError as e:
+    try:
+        from sonic_platform_base.sonic_storage.ssd import SsdUtil
+    except ImportError as e:
+        raise e
+s = SsdUtil('%s')
+print(json.dumps({'model': str(s.get_model()), 'firmware': str(s.get_firmware()), 'serial': str(s.get_serial()), 'health': str(s.get_health()), 'temperature': str(s.get_temperature()), 'vendor_output': str(s.get_vendor_output())}))
+`

--- a/show_client/helpers/platform_ssdhealth_helper.go
+++ b/show_client/helpers/platform_ssdhealth_helper.go
@@ -1,0 +1,208 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultSsdDevice = "/dev/sda"
+	hostMountPoint   = "/host"
+	// lsblk -J -o NAME,MAJ:MIN,TYPE,TRAN outputs JSON with block device info
+	lsblkJSONCmd = "lsblk -J -o NAME,MAJ:MIN,TYPE,TRAN"
+)
+
+// lsblkOutput represents the top-level JSON output of lsblk -J.
+type lsblkOutput struct {
+	BlockDevices []lsblkDevice `json:"blockdevices"`
+}
+
+// lsblkDevice represents a single block device entry from lsblk -J.
+type lsblkDevice struct {
+	Name   string  `json:"name"`
+	MajMin string  `json:"maj:min"`
+	Type   string  `json:"type"`
+	Tran   *string `json:"tran"`
+}
+
+// SsdInfo holds the SSD information retrieved from the Python SsdUtil API.
+type SsdInfo struct {
+	DiskType     string `json:"disk_type"`
+	Model        string `json:"model"`
+	Firmware     string `json:"firmware"`
+	Serial       string `json:"serial"`
+	Health       string `json:"health"`
+	Temperature  string `json:"temperature"`
+	VendorOutput string `json:"vendor_output"`
+}
+
+// GetDefaultDisk discovers the host disk device and transport type.
+func GetDefaultDisk() (defaultDevice string, diskType string) {
+	defaultDevice = defaultSsdDevice
+	diskType = ""
+
+	partitions, err := disk.Partitions(false)
+	if err != nil || partitions == nil {
+		log.V(4).Infof("Could not get disk partitions: %v", err)
+		return defaultDevice, diskType
+	}
+
+	var hostPartition disk.PartitionStat
+	found := false
+	for _, parts := range partitions {
+		if parts.Mountpoint == hostMountPoint {
+			hostPartition = parts
+			found = true
+			break
+		}
+	}
+	if !found {
+		log.V(4).Infof("No %s mount found in disk partitions", hostMountPoint)
+		return defaultDevice, diskType
+	}
+
+	var statResult unix.Stat_t
+	if err := unix.Stat(hostPartition.Device, &statResult); err != nil {
+		log.V(4).Infof("Could not stat %s: %v", hostPartition.Device, err)
+		return defaultDevice, diskType
+	}
+	diskMajor := unix.Major(uint64(statResult.Rdev))
+
+	majMinFilter := fmt.Sprintf("%d:0", diskMajor)
+
+	// (replicated via lsblk -J since Go has no blkinfo equivalent)
+	lsblkRaw, err := common.GetDataFromHostCommand(lsblkJSONCmd)
+	if err != nil {
+		log.V(4).Infof("Could not run lsblk: %v", err)
+		return defaultDevice, diskType
+	}
+
+	var lsblkResult lsblkOutput
+	if err := json.Unmarshal([]byte(lsblkRaw), &lsblkResult); err != nil {
+		log.V(4).Infof("Could not parse lsblk JSON: %v", err)
+		return defaultDevice, diskType
+	}
+
+	var matchedDisk lsblkDevice
+	diskFound := false
+	for _, dev := range lsblkResult.BlockDevices {
+		if dev.Type == "disk" && dev.MajMin == majMinFilter {
+			matchedDisk = dev
+			diskFound = true
+			break
+		}
+	}
+	if !diskFound {
+		log.V(4).Infof("No parent disk found with maj:min %s", majMinFilter)
+		return defaultDevice, diskType
+	}
+
+	defaultDevice = filepath.Join("/dev", matchedDisk.Name)
+	if matchedDisk.Tran != nil {
+		diskType = *matchedDisk.Tran
+	}
+
+	if len(diskType) == 0 && strings.Contains(hostPartition.Device, "mmcblk") {
+		diskType = "eMMC"
+	}
+
+	return defaultDevice, diskType
+}
+
+// ImportSsdApi loads the SSD utility (platform-specific or generic) via nsenter
+// and retrieves SSD health information for the given device.
+func ImportSsdApi(device string) (*SsdInfo, error) {
+	platformPath, _ := common.GetPathsToPlatformAndHwskuDirsOnHost()
+	pyScript := fmt.Sprintf(common.SsdHealthPyScript, platformPath, device)
+	shlexSafeScript := strings.ReplaceAll(pyScript, "'", `'\''`)
+	pyCmd := fmt.Sprintf("python3 -c '%s'", shlexSafeScript)
+
+	output, err := common.GetDataFromHostCommand(pyCmd)
+	if err != nil {
+		log.Errorf("ImportSsdApi: command failed for %s: %v", device, err)
+		return nil, fmt.Errorf("failed to get SSD info for %s: %w", device, err)
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		log.Errorf("ImportSsdApi: empty response for device %s", device)
+		return nil, fmt.Errorf("empty response from SSD utility for %s", device)
+	}
+
+	log.V(4).Infof("ImportSsdApi: raw output for %s: %s", device, output)
+
+	var info SsdInfo
+	if err := json.Unmarshal([]byte(output), &info); err != nil {
+		log.Errorf("ImportSsdApi: JSON parse failed for %s: %v", device, err)
+		return nil, fmt.Errorf("failed to parse SSD info JSON: %w", err)
+	}
+
+	log.V(4).Infof("ImportSsdApi: successfully parsed SSD info for %s", device)
+	return &info, nil
+}
+
+func GetSsdHealthData(device string) (*SsdInfo, error) {
+	/* GetSsdHealthData resolves the SSD device and retrieves health data.
+	 1. Use explicit device if provided (from args)
+	 2. Try platform.json: chassis.disk.device
+	 3. Call GetDefaultDisk() to discover /host partition's parent disk
+	 4. Call ImportSsdApi to get SSD info
+	Returns ssdInfo (with DiskType set) or error if SSD not detected. */
+	if device == "" {
+		platformData, err := common.GetPlatformJsonData()
+		if err == nil && platformData != nil {
+			device = common.GetNestedString(platformData, "chassis", "disk", "device")
+			if device != "" {
+				log.V(4).Infof("GetSsdHealthData: device from platform.json: %s", device)
+			}
+		} else if err != nil {
+			log.V(4).Infof("GetSsdHealthData: platform.json not available: %v", err)
+		}
+	}
+
+	defaultDevice, diskType := GetDefaultDisk()
+	log.V(4).Infof("GetSsdHealthData: default disk=%s, disk type=%s", defaultDevice, diskType)
+
+	if device == "" {
+		device = defaultDevice
+	}
+
+	ssdInfo, err := ImportSsdApi(device)
+	if err != nil {
+		log.Errorf("GetSsdHealthData: failed to get SSD info for %s: %v", device, err)
+		return nil, err
+	}
+
+	ssdInfo.DiskType = diskType
+	return ssdInfo, nil
+}
+
+// IsNumber checks if a string can be parsed as a float.
+func IsNumber(s string) bool {
+	_, err := strconv.ParseFloat(s, 64)
+	return err == nil
+}
+
+// FormatHealth formats the health value with % suffix if numeric.
+func FormatHealth(health string) string {
+	if IsNumber(health) {
+		return health + "%"
+	}
+	return health
+}
+
+// FormatTemperature formats the temperature value with C suffix if numeric.
+func FormatTemperature(temperature string) string {
+	if IsNumber(temperature) {
+		return temperature + "C"
+	}
+	return temperature
+}

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -93,6 +93,23 @@ type CurrentInfo struct {
 	Timestamp  string `json:"timestamp"`
 }
 
+// SsdHealthInfo represents SSD health information.
+// Fields are conditionally populated based on verbose/vendor options,
+// matching Python ssdutil output:
+//
+//	always:  disk_type, device_model, health, temperature
+//	verbose: +firmware, +serial
+//	vendor:  +vendor_output
+type SsdHealthInfo struct {
+	DiskType     string `json:"disk_type"`
+	DeviceModel  string `json:"device_model"`
+	Firmware     string `json:"firmware,omitempty"`
+	Serial       string `json:"serial,omitempty"`
+	Health       string `json:"health"`
+	Temperature  string `json:"temperature"`
+	VendorOutput string `json:"vendor_output,omitempty"`
+}
+
 // getPlatformSummary implements the "show platform summary" command
 func getPlatformSummary(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
 	// Get version info to extract ASIC type
@@ -392,4 +409,38 @@ func getPlatformCurrent(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 			Timestamp:  data["timestamp"],
 		}
 	})
+}
+
+// getPlatformSsdhealth implements the "show platform ssdhealth" command.
+func getPlatformSsdhealth(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	var device string
+	if len(args) > 0 {
+		device = args[0]
+	}
+
+	ssdInfo, err := helpers.GetSsdHealthData(device)
+	if err != nil {
+		log.Infof("SSD not detected: %v", err)
+		return json.Marshal(map[string]string{"message": "SSD not detected"})
+	}
+
+	ssdHealth := SsdHealthInfo{
+		DiskType:    strings.ToUpper(ssdInfo.DiskType),
+		DeviceModel: ssdInfo.Model,
+		Health:      helpers.FormatHealth(ssdInfo.Health),
+		Temperature: helpers.FormatTemperature(ssdInfo.Temperature),
+	}
+
+	if verbose, ok := options[OptionKeyVerbose].Bool(); ok && verbose {
+		log.V(4).Infof("Verbose mode enabled, adding firmware=%s, serial=%s", ssdInfo.Firmware, ssdInfo.Serial)
+		ssdHealth.Firmware = ssdInfo.Firmware
+		ssdHealth.Serial = ssdInfo.Serial
+	}
+
+	if vendor, ok := options[OptionKeyVendor].Bool(); ok && vendor {
+		log.V(4).Infof("Vendor mode enabled, adding vendor_output (len=%d)", len(ssdInfo.VendorOutput))
+		ssdHealth.VendorOutput = ssdInfo.VendorOutput
+	}
+
+	return json.Marshal(ssdHealth)
 }

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -35,6 +35,7 @@ const (
 	showCmdOptionLinesDesc             = "[lines=INTEGER] Number of lines to show (default: 10)"
 	showCmdOptionPsuIndexDesc          = "[index=INTEGER] Display a specific PSU by index"
 	showCmdOptionHistoryDesc           = "[history=true] Display historical PFC statistics"
+	showCmdOptionVendorDesc            = "[vendor=true] Show vendor output (extended output if provided by platform vendor)"
 )
 
 // Option keys
@@ -42,6 +43,7 @@ const (
 	OptionKeyVerbose  = "verbose"
 	SonicCliIfaceMode = "SONIC_CLI_IFACE_MODE"
 	OptionKeyPsuIndex = "index"
+	OptionKeyVendor   = "vendor"
 )
 
 var (
@@ -231,6 +233,12 @@ var (
 	showCmdOptionHistory = sdc.NewShowCmdOption(
 		"history",
 		showCmdOptionHistoryDesc,
+		sdc.BoolValue,
+	)
+
+	showCmdOptionVendor = sdc.NewShowCmdOption(
+		OptionKeyVendor,
+		showCmdOptionVendorDesc,
 		sdc.BoolValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1143,7 +1143,7 @@ func init() {
 		showCmdOptionVerbose,
 		showCmdOptionVendor,
 	)
-  
+
 	//SHOW/management-interface/address
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "management-interface", "address"},

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1131,4 +1131,16 @@ func init() {
 		0,
 		nil,
 	)
+
+	// SHOW/platform/ssdhealth
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "platform", "ssdhealth"},
+		getPlatformSsdhealth,
+		"SHOW/platform/ssdhealth/{DEVICE}[OPTIONS]: Show platform SSD health",
+		0,
+		1,
+		nil,
+		showCmdOptionVerbose,
+		showCmdOptionVendor,
+	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1142,7 +1142,7 @@ func init() {
 		nil,
 		showCmdOptionVerbose,
 		showCmdOptionVendor,
-  )
+	)
   
 	//SHOW/management-interface/address
 	sdc.RegisterCliPath(


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
MSFT ADO: 37750109

#### Why I did it

Onboarded show platform ssdhealth command to gNMI server so SSD health data of a device (model, firmware, serial, health, temperature, vendor output) can be queried programmatically via gNMI Get/Subscribe RPCs.

#### How I did it
Added platform_ssdhealth_helper.go in helpers that finds the default host disk via partition/lsblk lookups if the device is not given as input, runs a Python SsdUtil script on the host via nsenter to get the ssd health, and parses the JSON result. 

Note- show paltform ssdhealth --vendor output varies based on different vendor.

#### How to verify it
**Mellanox device**
```
admin@bjw2-can-4600c-5:~$ show platform ssdhealth
Disk Type    : SATA
Device Model : VSFCM4XC030G-B201
Health       : 99.61333333333333%
Temperature  : 50C
admin@bjw2-can-4600c-5:~$ show platform ssdhealth --verbose
Running command: sudo ssdutil -v
Disk Type    : SATA
Device Model : VSFCM4XC030G-B201
Firmware     : 0924-000
Serial       : 57827-0297
Health       : 99.61333333333333%
Temperature  : 49C
admin@bjw2-can-4600c-5:~$ show platform ssdhealth --vendor
Disk Type    : SATA
Device Model : VSFCM4XC030G-B201
Health       : 99.61333333333333%
Temperature  : 49C
SMART attributes
 ID                    Attribute   High Raw    Low Raw Value Worst Threshold
  1          Raw_Read_Error_Rate          0          0   100   100        47
  5           Reserved_Attribute          0          0   100   100        51
  9               Power_On_Hours          0      16857   100   100        50
 12            Power_Cycle_Count          0        110   100   100        50
160   Uncorrectable_Sector_Count          0          0   100   100        50
161            Valid_Spare_Block          0       2240   100   100        50
163           Reserved_Attribute          0         37   100   100        50
164           Reserved_Attribute          0     171348   100   100        50
165          Maximum_Erase_Count          0        159   100   100        50
166           Reserved_Attribute          0          3   100   100        50
167          Average_Erase_Count          0        116   100   100        50
168               NAND_Endurance          0      30000   100   100        50
177           Reserved_Attribute          0       1319   100   100        50
181           Total_Program_Fail          0          0   100   100        50
182             Total_Erase_Fail          0          0   100   100        50
187    Uncorrectable_Error_Count          0          0   100   100        50
192      Sudden_Power_Lost_Count          0        109   100   100        50
194          Temperature_Celsius          0         49   100   100        34
195       Hardware_ECC_Recovered          0          0   100   100        58
196      Reallocated_Event_Count          0          0   100   100        50
198           Reserved_Attribute          0          0   100   100        50
199         UDMA_CRC_Error_Count          0          0   100   100        50
232           Reserved_Attribute          0        100   100   100        50
241           Total_LBAs_Written          0     458615   100   100        50
242              Total_LBAs_Read          0     302620   100   100        50
248          Remaining_Life_Left          0        100   100   100        50
249  Remaining_Spare_Block_Count          0        100   100   100        50
250        Total_Written_To_NAND          0     502153   100   100        50
251       Unaligned_Access_Count          0          0   100   100        50
admin@bjw2-can-4600c-5:~$
admin@bjw2-can-4600c-5:~$ show platform ssdhealth /dev/sda
Disk Type    : SATA
Device Model : VSFCM4XC030G-B201
Health       : 99.61333333333333%
Temperature  : 46C
``` 

gNMI output
```
root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777457436545595394
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"SATA\",\"device_model\":\"VSFCM4XC030G-B201\",\"health\":\"99.61333333333333%\",\"temperature\":\"47C\"}"
    >
  >
>

root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[verbose=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "verbose"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777457480499353571
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "verbose"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"SATA\",\"device_model\":\"VSFCM4XC030G-B201\",\"firmware\":\"0924-000\",\"serial\":\"57827-0297\",\"health\":\"99.61333333333333%\",\"temperature\":\"47C\"}"
    >
  >
>

root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[vendor=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "vendor"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777457492307832480
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "vendor"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"SATA\",\"device_model\":\"VSFCM4XC030G-B201\",\"health\":\"99.61333333333333%\",\"temperature\":\"47C\",\"vendor_output\":\"SMART attributes \\n ID                    Attribute   High Raw    Low Raw Value Worst Threshold \\n  1          Raw_Read_Error_Rate          0          0   100   100        47 \\n  5           Reserved_Attribute          0          0   100   100        51 \\n  9               Power_On_Hours          0      16857   100   100        50 \\n 12            Power_Cycle_Count          0        110   100   100        50 \\n160   Uncorrectable_Sector_Count          0          0   100   100        50 \\n161            Valid_Spare_Block          0       2240   100   100        50 \\n163           Reserved_Attribute          0         37   100   100        50 \\n164           Reserved_Attribute          0     171348   100   100        50 \\n165          Maximum_Erase_Count          0        159   100   100        50 \\n166           Reserved_Attribute          0          3   100   100        50 \\n167          Average_Erase_Count          0        116   100   100        50 \\n168               NAND_Endurance          0      30000   100   100        50 \\n177           Reserved_Attribute          0       1319   100   100        50 \\n181           Total_Program_Fail          0          0   100   100        50 \\n182             Total_Erase_Fail          0          0   100   100        50 \\n187    Uncorrectable_Error_Count          0          0   100   100        50 \\n192      Sudden_Power_Lost_Count          0        109   100   100        50 \\n194          Temperature_Celsius          0         47   100   100        34 \\n195       Hardware_ECC_Recovered          0          0   100   100        58 \\n196      Reallocated_Event_Count          0          0   100   100        50 \\n198           Reserved_Attribute          0          0   100   100        50 \\n199         UDMA_CRC_Error_Count          0          0   100   100        50 \\n232           Reserved_Attribute          0        100   100   100        50 \\n241           Total_LBAs_Written          0     458616   100   100        50 \\n242              Total_LBAs_Read          0     302620   100   100        50 \\n248          Remaining_Life_Left          0        100   100   100        50 \\n249  Remaining_Spare_Block_Count          0        100   100   100        50 \\n250        Total_Written_To_NAND          0     502154   100   100        50 \\n251       Unaligned_Access_Count          0          0   100   100        50 \\n\\n\"}"
    >
  >
>

root@bjw2-can-4600c-5:/#
admin@bjw2-can-4600c-5:~$ docker exec -it telemetry bash
root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth/\\/dev\\/sda -target_addr 127.0.0.1:50051
 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
  >
  elem: <
    name: "/dev/sda"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777459891094945604
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
      >
      elem: <
        name: "/dev/sda"
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"SATA\",\"device_model\":\"VSFCM4XC030G-B201\",\"health\":\"99.61333333333333%\",\"temperature\":\"46C\"}"
    >
  >
>
``` 


**Cisco device-
CLI output**
```
admin@str3-cisco-8102-E04-U26:~$ show platform ssdhealth
Disk Type    : NVME
Device Model : Micron_7450_MTFDKBA400TFS
Health       : N/A
Temperature  : 54.0C
admin@str3-cisco-8102-E04-U26:~$ show platform ssdhealth --verbose
Running command: sudo ssdutil -v
Disk Type    : NVME
Device Model : Micron_7450_MTFDKBA400TFS
Firmware     : E2MU200
Serial       : MSA291100WM
Health       : N/A
Temperature  : 53.0C
admin@str3-cisco-8102-E04-U26:~$ show platform ssdhealth --vendor
Disk Type    : NVME
Device Model : Micron_7450_MTFDKBA400TFS
Health       : N/A
Temperature  : 54.0C
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.41+deb13-sonic-amd64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       Micron_7450_MTFDKBA400TFS
Serial Number:                      MSA291100WM
Firmware Version:                   E2MU200
PCI Vendor/Subsystem ID:            0x1344
IEEE OUI Identifier:                0x00a075
Total NVM Capacity:                 400,088,457,216 [400 GB]
Unallocated NVM Capacity:           159,570,288,640 [159 GB]
Controller ID:                      0
NVMe Version:                       1.4
Number of Namespaces:               132
Namespace 1 Size/Capacity:          240,000,000,000 [240 GB]
Namespace 1 Utilization:            9,503,461,376 [9.50 GB]
Namespace 1 Formatted LBA Size:     512
Namespace 1 IEEE EUI-64:            00a075 024eda8b82
Local Time is:                      Wed Apr 29 08:47:59 2026 UTC
Firmware Updates (0x17):            3 Slots, Slot 1 R/O, no Reset required
Optional Admin Commands (0x005e):   Format Frmw_DL NS_Mngmt Self_Test MI_Snd/Rec
Optional NVM Commands (0x00df):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat Timestmp Verify
Log Page Attributes (0x1e):         Cmd_Eff_Lg Ext_Get_Lg Telmtry_Lg Pers_Ev_Lg
Maximum Data Transfer Size:         1024 Pages
Warning  Comp. Temp. Threshold:     77 Celsius
Critical Comp. Temp. Threshold:     85 Celsius
Namespace 1 Features (0x16):        NA_Fields Dea/Unw_Error NP_Fields

Supported Power States
St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
 0 +     8.25W       -        -    0  0  0  0        0       0
 1 +     7.00W       -        -    1  1  1  1        0       0
 2 +     6.00W       -        -    2  2  2  2        0       0
 3 +     5.00W       -        -    3  3  3  3        0       0
 4 +     4.00W       -        -    4  4  4  4        0       0

Supported LBA Sizes (NSID 0x1)
Id Fmt  Data  Metadt  Rel_Perf
 0 +     512       0         2
 1 -    4096       0         0

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02)
Critical Warning:                   0x00
Temperature:                        54 Celsius
Available Spare:                    100%
Available Spare Threshold:          10%
Percentage Used:                    0%
Data Units Read:                    57,102,531 [29.2 TB]
Data Units Written:                 984,404 [504 GB]
Host Read Commands:                 223,674,438
Host Write Commands:                43,700,444
Controller Busy Time:               147
Power Cycles:                       80
Power On Hours:                     6,034
Unsafe Shutdowns:                   51
Media and Data Integrity Errors:    0
Error Information Log Entries:      0
Warning  Comp. Temperature Time:    0
Critical Comp. Temperature Time:    0
Temperature Sensor 1:               60 Celsius
Temperature Sensor 2:               56 Celsius
Temperature Sensor 3:               54 Celsius

Error Information (NVMe Log 0x01, 16 of 256 entries)
No Errors Logged

Read Self-test Log failed: Invalid Field in Command (0x4002)
``` 

**gnmi output-**
```
admin@str3-cisco-8102-E04-U26:~$ docker exec -it telemetry bash
root@str3-cisco-8102-E04-U26:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777452243289503570
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"Micron_7450_MTFDKBA400TFS\",\"health\":\"N/A\",\"temperature\":\"54.0C\"}"
    >
  >
>

root@str3-cisco-8102-E04-U26:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[verbose=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "verbose"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777452260283146836
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "verbose"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"Micron_7450_MTFDKBA400TFS\",\"firmware\":\"E2MU200\",\"serial\":\"MSA291100WM\",\"health\":\"N/A\",\"temperature\":\"54.0C\"}"
    >
  >
>

root@str3-cisco-8102-E04-U26:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[vendor=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "vendor"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777452270888144227
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "vendor"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"Micron_7450_MTFDKBA400TFS\",\"health\":\"N/A\",\"temperature\":\"53.0C\",\"vendor_output\":\"smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.41+deb13-sonic-amd64] (local build)\\nCopyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org\\n\\n=== START OF INFORMATION SECTION ===\\nModel Number:                       Micron_7450_MTFDKBA400TFS\\nSerial Number:                      MSA291100WM\\nFirmware Version:                   E2MU200\\nPCI Vendor/Subsystem ID:            0x1344\\nIEEE OUI Identifier:                0x00a075\\nTotal NVM Capacity:                 400,088,457,216 [400 GB]\\nUnallocated NVM Capacity:           159,570,288,640 [159 GB]\\nController ID:                      0\\nNVMe Version:                       1.4\\nNumber of Namespaces:               132\\nNamespace 1 Size/Capacity:          240,000,000,000 [240 GB]\\nNamespace 1 Utilization:            9,503,383,552 [9.50 GB]\\nNamespace 1 Formatted LBA Size:     512\\nNamespace 1 IEEE EUI-64:            00a075 024eda8b82\\nLocal Time is:                      Wed Apr 29 08:44:31 2026 UTC\\nFirmware Updates (0x17):            3 Slots, Slot 1 R/O, no Reset required\\nOptional Admin Commands (0x005e):   Format Frmw_DL NS_Mngmt Self_Test MI_Snd/Rec\\nOptional NVM Commands (0x00df):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat Timestmp Verify\\nLog Page Attributes (0x1e):         Cmd_Eff_Lg Ext_Get_Lg Telmtry_Lg Pers_Ev_Lg\\nMaximum Data Transfer Size:         1024 Pages\\nWarning  Comp. Temp. Threshold:     77 Celsius\\nCritical Comp. Temp. Threshold:     85 Celsius\\nNamespace 1 Features (0x16):        NA_Fields Dea/Unw_Error NP_Fields\\n\\nSupported Power States\\nSt Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat\\n 0 +     8.25W       -        -    0  0  0  0        0       0\\n 1 +     7.00W       -        -    1  1  1  1        0       0\\n 2 +     6.00W       -        -    2  2  2  2        0       0\\n 3 +     5.00W       -        -    3  3  3  3        0       0\\n 4 +     4.00W       -        -    4  4  4  4        0       0\\n\\nSupported LBA Sizes (NSID 0x1)\\nId Fmt  Data  Metadt  Rel_Perf\\n 0 +     512       0         2\\n 1 -    4096       0         0\\n\\n=== START OF SMART DATA SECTION ===\\nSMART overall-health self-assessment test result: PASSED\\n\\nSMART/Health Information (NVMe Log 0x02)\\nCritical Warning:                   0x00\\nTemperature:                        53 Celsius\\nAvailable Spare:                    100%\\nAvailable Spare Threshold:          10%\\nPercentage Used:                    0%\\nData Units Read:                    57,102,531 [29.2 TB]\\nData Units Written:                 984,400 [504 GB]\\nHost Read Commands:                 223,674,438\\nHost Write Commands:                43,700,165\\nController Busy Time:               147\\nPower Cycles:                       80\\nPower On Hours:                     6,034\\nUnsafe Shutdowns:                   51\\nMedia and Data Integrity Errors:    0\\nError Information Log Entries:      0\\nWarning  Comp. Temperature Time:    0\\nCritical Comp. Temperature Time:    0\\nTemperature Sensor 1:               61 Celsius\\nTemperature Sensor 2:               56 Celsius\\nTemperature Sensor 3:               53 Celsius\\n\\nError Information (NVMe Log 0x01, 16 of 256 entries)\\nNo Errors Logged\\n\\nRead Self-test Log failed: Invalid Field in Command (0x4002)\\n\\n\"}"
    >
  >
>
``` 
**Arista device**
**CLI output**
admin@str4-7060x6-512-11:~$ show platform ssdhealth
Disk Type    : NVME
Device Model : W6EN240G8TAZ-PE4A5-4D2.E5
Health       : 100.0%
Temperature  : 39.0C

admin@str4-7060x6-512-11:~$ show platform ssdhealth --verbose
Running command: sudo ssdutil -v
Disk Type    : NVME
Device Model : W6EN240G8TAZ-PE4A5-4D2.E5
Firmware     : EIEM51.5
Serial       : 109-0124955-00266
Health       : 100.0%
Temperature  : 39.0C

admin@str4-7060x6-512-11:~$ show platform ssdhealth --vendor
Disk Type    : NVME
Device Model : W6EN240G8TAZ-PE4A5-4D2.E5
Health       : 100.0%
Temperature  : 39.0C
N/A

**gNMI output**
```
admin@str4-7060x6-512-11:~$ docker exec -it telemetry bash
root@str4-7060x6-512-11:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777532070679881014
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"W6EN240G8TAZ-PE4A5-4D2.E5\",\"health\":\"100.0%\",\"temperature\":\"39.0C\"}"
    >
  >
>

root@str4-7060x6-512-11:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[verbose=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "verbose"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777532123133544350
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "verbose"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"W6EN240G8TAZ-PE4A5-4D2.E5\",\"firmware\":\"EIEM51.5\",\"serial\":\"109-0124955-00266\",\"health\":\"100.0%\",\"temperature\":\"39.0C\"}"
    >
  >
>

root@str4-7060x6-512-11:/# gnmi_get -xpath_target SHOW -xpath platform/ssdhealth[vendor=true] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "ssdhealth"
    key: <
      key: "vendor"
      value: "true"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777532135099086131
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "ssdhealth"
        key: <
          key: "vendor"
          value: "true"
        >
      >
    >
    val: <
      json_ietf_val: "{\"disk_type\":\"NVME\",\"device_model\":\"W6EN240G8TAZ-PE4A5-4D2.E5\",\"health\":\"100.0%\",\"temperature\":\"39.0C\",\"vendor_output\":\"N/A\"}"
    >
  >
>
``` 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

