### PR TITLE
Onboard code for show system-health sysready-status

### DIFF
--- a/gnmi_server/platform_system_health_cli_test.go
+++ b/gnmi_server/platform_system_health_cli_test.go
@@ -858,7 +858,7 @@ func TestGetShowSystemHealthSysreadyStatus(t *testing.T) {
 				elem: <name: "system-health" >
 				elem: <name: "sysready-status" >
 			`,
-			wantRetCode: codes.Internal,
+			wantRetCode: codes.NotFound,
 			valTest:     false,
 			testInit: func() {
 				FlushDataSet(t, StateDbNum)

--- a/gnmi_server/platform_system_health_cli_test.go
+++ b/gnmi_server/platform_system_health_cli_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
 	sccommon "github.com/sonic-net/sonic-gnmi/show_client/common"
+	"github.com/sonic-net/sonic-gnmi/show_client/helpers"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -767,4 +768,110 @@ func mockSystemWithIgnoreConfig(t *testing.T) *gomonkey.Patches {
 	mockDBQueries(t, patches, systemHealthTemperatureFailFile)
 
 	return patches
+}
+
+func TestGetShowSystemHealthSysreadyStatus(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW system-health sysready-status - system ready",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "system-health" >
+				elem: <name: "sysready-status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: func() []byte {
+				expected := helpers.SysreadyStatus{
+					SystemStatus: "System is ready",
+					Services: []helpers.SysreadyService{
+						{ServiceName: "bgp", ServiceStatus: "OK", AppReadyStatus: "OK", DownReason: "-"},
+						{ServiceName: "swss", ServiceStatus: "OK", AppReadyStatus: "OK", DownReason: "-"},
+						{ServiceName: "syncd", ServiceStatus: "OK", AppReadyStatus: "OK", DownReason: "-"},
+					},
+				}
+				jsonData, _ := json.Marshal(expected)
+				return jsonData
+			}(),
+			valTest: true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, "../testdata/SYSREADY_STATUS.txt")
+			},
+		},
+		{
+			desc:       "query SHOW system-health sysready-status - system not ready",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "system-health" >
+				elem: <name: "sysready-status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: func() []byte {
+				expected := helpers.SysreadyStatus{
+					SystemStatus: "System is not ready - one or more services are not up",
+					Services: []helpers.SysreadyService{
+						{ServiceName: "bgp", ServiceStatus: "OK", AppReadyStatus: "OK", DownReason: "-"},
+						{ServiceName: "swss", ServiceStatus: "OK", AppReadyStatus: "Down", DownReason: "orchagent is not responsive"},
+						{ServiceName: "syncd", ServiceStatus: "Down", AppReadyStatus: "Down", DownReason: "syncd service not running"},
+					},
+				}
+				jsonData, _ := json.Marshal(expected)
+				return jsonData
+			}(),
+			valTest: true,
+			testInit: func() {
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, StateDbNum, "../testdata/SYSREADY_STATUS_NOT_READY.txt")
+			},
+		},
+		{
+			desc:       "query SHOW system-health sysready-status - no data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "system-health" >
+				elem: <name: "sysready-status" >
+			`,
+			wantRetCode: codes.Internal,
+			valTest:     false,
+			testInit: func() {
+				FlushDataSet(t, StateDbNum)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+	}
 }

--- a/show_client/helpers/system_health_helper.go
+++ b/show_client/helpers/system_health_helper.go
@@ -264,14 +264,7 @@ func GetSysreadyStatus() (string, error) {
 		return "", fmt.Errorf("failed to read system ready state: %v", err)
 	}
 
-	if len(data) == 0 {
-		return "", fmt.Errorf("no system ready status data available - system-health service might be down")
-	}
-
 	raw := common.GetValueOrDefault(data, sysreadyStatusField, "")
-	if raw == "" {
-		return "", nil
-	}
 	if strings.EqualFold(raw, "UP") {
 		return "System is ready", nil
 	}

--- a/show_client/helpers/system_health_helper.go
+++ b/show_client/helpers/system_health_helper.go
@@ -5,8 +5,38 @@ import (
 	"sort"
 	"strings"
 
+	log "github.com/golang/glog"
+	natural "github.com/maruel/natural"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
 	"github.com/sonic-net/sonic-gnmi/show_client/helpers/health_checker"
 )
+
+// Redis table/field constants for sysready-status
+const (
+	sysreadyTable       = "SYSTEM_READY"
+	sysreadyKey         = "SYSTEM_STATE"
+	sysreadyStatusField = "Status"
+
+	serviceStatusTable = "ALL_SERVICE_STATUS"
+
+	serviceStatusField  = "service_status"
+	appReadyStatusField = "app_ready_status"
+	failReasonField     = "fail_reason"
+)
+
+// SysreadyStatus is the top-level JSON response for sysready-status commands.
+type SysreadyStatus struct {
+	SystemStatus string            `json:"system_status"`
+	Services     []SysreadyService `json:"services,omitempty"`
+}
+
+// SysreadyService represents one row in the sysready-status service table.
+type SysreadyService struct {
+	ServiceName    string `json:"service_name"`
+	ServiceStatus  string `json:"service_status"`
+	AppReadyStatus string `json:"app_ready_status"`
+	DownReason     string `json:"down_reason"`
+}
 
 // SystemHealthSummary represents the output structure for show system-health summary.
 type SystemHealthSummary struct {
@@ -221,4 +251,69 @@ func DisplayIgnoreList(manager *health_checker.HealthCheckerManager) []HealthLis
 		return entries[i].Name < entries[j].Name
 	})
 	return entries
+}
+
+// GetSysreadyStatus queries STATE_DB for the system ready state
+// and returns "System is ready" or "System is not ready".
+func GetSysreadyStatus() (string, error) {
+	queries := [][]string{
+		{common.StateDb, sysreadyTable, sysreadyKey},
+	}
+	data, err := common.GetMapFromQueries(queries)
+	if err != nil {
+		return "", fmt.Errorf("failed to read system ready state: %v", err)
+	}
+
+	if len(data) == 0 {
+		return "", fmt.Errorf("no system ready status data available - system-health service might be down")
+	}
+
+	raw := common.GetValueOrDefault(data, sysreadyStatusField, "")
+	if raw == "" {
+		return "", nil
+	}
+	if strings.EqualFold(raw, "UP") {
+		return "System is ready", nil
+	}
+	return "System is not ready - one or more services are not up", nil
+}
+
+// GetSysreadyServices queries ALL_SERVICE_STATUS from STATE_DB and returns
+// the naturally sorted list of service entries.
+func GetSysreadyServices() ([]SysreadyService, error) {
+	queries := [][]string{
+		{common.StateDb, serviceStatusTable},
+	}
+	data, err := common.GetMapFromQueries(queries)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	serviceKeys := make([]string, 0, len(data))
+	for k := range data {
+		serviceKeys = append(serviceKeys, k)
+	}
+	sort.Sort(natural.StringSlice(serviceKeys))
+
+	services := make([]SysreadyService, 0, len(serviceKeys))
+
+	for _, key := range serviceKeys {
+		info, ok := data[key].(map[string]interface{})
+		if !ok {
+			log.V(2).Infof("getSysreadyServices: skipping invalid entry for key %q", key)
+			continue
+		}
+
+		svc := SysreadyService{
+			ServiceName:    key,
+			ServiceStatus:  common.GetValueOrDefault(info, serviceStatusField, ""),
+			AppReadyStatus: common.GetValueOrDefault(info, appReadyStatusField, ""),
+			DownReason:     common.GetValueOrDefault(info, failReasonField, ""),
+		}
+		services = append(services, svc)
+	}
+	return services, nil
 }

--- a/show_client/platform_system_health_cli.go
+++ b/show_client/platform_system_health_cli.go
@@ -111,3 +111,27 @@ func getSystemHealthMonitorList(args sdc.CmdArgs, options sdc.OptionMap) ([]byte
 
 	return json.Marshal(result)
 }
+
+func getSystemHealthSysreadyStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	/* getSystemHealthSysreadyStatus implements "show system-health sysready-status".
+	   Shows system ready status and per-service table.
+	*/
+	sysStatus, err := helpers.GetSysreadyStatus()
+	if err != nil {
+		return nil, err
+	}
+
+	services, err := helpers.GetSysreadyServices()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query service status: %w", err)
+	}
+	if services == nil && sysStatus == "" {
+		return nil, fmt.Errorf("No system ready status data available")
+	}
+
+	result := helpers.SysreadyStatus{
+		SystemStatus: sysStatus,
+		Services:     services,
+	}
+	return json.Marshal(result)
+}

--- a/show_client/platform_system_health_cli.go
+++ b/show_client/platform_system_health_cli.go
@@ -116,17 +116,18 @@ func getSystemHealthSysreadyStatus(args sdc.CmdArgs, options sdc.OptionMap) ([]b
 	/* getSystemHealthSysreadyStatus implements "show system-health sysready-status".
 	   Shows system ready status and per-service table.
 	*/
-	sysStatus, err := helpers.GetSysreadyStatus()
-	if err != nil {
-		return nil, err
-	}
-
 	services, err := helpers.GetSysreadyServices()
 	if err != nil {
 		return nil, fmt.Errorf("failed to query service status: %w", err)
 	}
-	if services == nil && sysStatus == "" {
-		return nil, fmt.Errorf("No system ready status data available")
+
+	if services == nil {
+		return nil, fmt.Errorf("No system ready status data available - system-health service might be down")
+	}
+
+	sysStatus, err := helpers.GetSysreadyStatus()
+	if err != nil {
+		return nil, err
 	}
 
 	result := helpers.SysreadyStatus{

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1131,4 +1131,14 @@ func init() {
 		0,
 		nil,
 	)
+
+	// SHOW/system-health/sysready-status
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "system-health", "sysready-status"},
+		getSystemHealthSysreadyStatus,
+		"SHOW/system-health/sysready-status: Show system ready status",
+		0,
+		0,
+		nil,
+	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1163,14 +1163,14 @@ func init() {
 		0,
 		nil,
 	)
-  
-  // SHOW/system-health/sysready-status
-  sdc.RegisterCliPath(
-    []string{"SHOW", "system-health", "sysready-status"},
-    getSystemHealthSysreadyStatus,
-    "SHOW/system-health/sysready-status: Show system ready status",
-    0,
-    0,
-    nil,
-  )
+
+	// SHOW/system-health/sysready-status
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "system-health", "sysready-status"},
+		getSystemHealthSysreadyStatus,
+		"SHOW/system-health/sysready-status: Show system ready status",
+		0,
+		0,
+		nil,
+	)
 }

--- a/testdata/SYSREADY_STATUS.txt
+++ b/testdata/SYSREADY_STATUS.txt
@@ -1,0 +1,23 @@
+{
+    "SYSTEM_READY|SYSTEM_STATE": {
+        "Status": "UP"
+    },
+    "ALL_SERVICE_STATUS|bgp": {
+        "service_status": "OK",
+        "app_ready_status": "OK",
+        "fail_reason": "-",
+        "update_time": "2026-04-25 10:00:00"
+    },
+    "ALL_SERVICE_STATUS|swss": {
+        "service_status": "OK",
+        "app_ready_status": "OK",
+        "fail_reason": "-",
+        "update_time": "2026-04-25 10:00:01"
+    },
+    "ALL_SERVICE_STATUS|syncd": {
+        "service_status": "OK",
+        "app_ready_status": "OK",
+        "fail_reason": "-",
+        "update_time": "2026-04-25 10:00:02"
+    }
+}

--- a/testdata/SYSREADY_STATUS_NOT_READY.txt
+++ b/testdata/SYSREADY_STATUS_NOT_READY.txt
@@ -1,0 +1,23 @@
+{
+    "SYSTEM_READY|SYSTEM_STATE": {
+        "Status": "DOWN"
+    },
+    "ALL_SERVICE_STATUS|bgp": {
+        "service_status": "OK",
+        "app_ready_status": "OK",
+        "fail_reason": "-",
+        "update_time": "2026-04-25 10:00:00"
+    },
+    "ALL_SERVICE_STATUS|swss": {
+        "service_status": "OK",
+        "app_ready_status": "Down",
+        "fail_reason": "orchagent is not responsive",
+        "update_time": "2026-04-25 10:00:01"
+    },
+    "ALL_SERVICE_STATUS|syncd": {
+        "service_status": "Down",
+        "app_ready_status": "Down",
+        "fail_reason": "syncd service not running",
+        "update_time": "2026-04-25 10:00:02"
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
MSFT ADO- 37750118

#### Why I did it
Added gNMI getter for show system-health sysready-status so client can fetch platform information via gNMI in JSON format.
#### How I did it
Added gNMI get function for the command which fetches services data from STATE_DB

#### How to verify it
**CLI output**
```
admin@bjw2-can-4600c-5:~$ show system-health sysready-status
System is ready

Service-Name                       Service-Status    App-Ready-Status    Down-Reason
---------------------------------  ----------------  ------------------  --------------
acms                               OK                OK                  -
audit-rules                        OK                OK                  -
auditd                             OK                OK                  -
bgp                                OK                OK                  -
caclmgrd                           OK                OK                  -
chrony                             OK                OK                  -
config-chassisdb                   OK                OK                  -
config-setup                       OK                OK                  -
containerd                         OK                OK                  -
core_uploader                      OK                OK                  -
cron                               OK                OK                  -
ctrmgrd                            OK                OK                  -
database                           OK                OK                  -
determine-reboot-cause             OK                OK                  -
dhcp_relay                         OK                OK                  -
docker                             OK                OK                  -
dpu-udev-manager                   OK                OK                  -
e2scrub_reap                       OK                OK                  -
eventd                             OK                OK                  -
gnmi                               OK                OK                  -
gnoi-shutdown                      OK                OK                  exec-condition
hw-management                      OK                OK                  -
hw-management-blacklist-generator  OK                OK                  -
hw-management-fast-sysfs-monitor   OK                OK                  -
hw-management-peripheral-updater   OK                OK                  -
hw-management-sysfs-monitor        OK                OK                  -
hw-management-tc                   OK                OK                  -
hw-management-thermal-updater      OK                OK                  -
lldp                               OK                OK                  -
monit                              OK                OK                  -
netfilter-persistent               OK                OK                  -
nv-syncd-shared                    OK                OK                  -
otel                               OK                OK                  -
pmon                               OK                OK                  -
procdockerstatsd                   OK                OK                  -
process-reboot-cause               OK                OK                  -
radv                               OK                OK                  -
ras-mc-ctl                         OK                OK                  -
restapi                            OK                OK                  -
rsyslog                            OK                OK                  -
smartmontools                      OK                OK                  -
snmp                               OK                OK                  -
ssh                                OK                OK                  -
swss                               OK                OK                  -
syncd                              OK                OK                  -
sysfsutils                         OK                OK                  -
sysstat                            OK                OK                  -
teamd                              OK                OK                  -
telemetry                          OK                OK                  -
``` 

**gNMI output**
```
root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath system-health/sysready-status -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "system-health"
  >
  elem: <
    name: "sysready-status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777461255742335894
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "system-health"
      >
      elem: <
        name: "sysready-status"
      >
    >
    val: <
      json_ietf_val: "{\"system_status\":\"System is ready\",\"services\":[{\"service_name\":\"acms\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"audit-rules\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"auditd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"bgp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"caclmgrd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"chrony\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"config-chassisdb\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"config-setup\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"containerd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"core_uploader\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"cron\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ctrmgrd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"database\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"determine-reboot-cause\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"dhcp_relay\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"docker\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"dpu-udev-manager\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"e2scrub_reap\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"eventd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"gnmi\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"gnoi-shutdown\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"exec-condition\"},{\"service_name\":\"hw-management\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-blacklist-generator\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-fast-sysfs-monitor\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-peripheral-updater\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-sysfs-monitor\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-tc\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"hw-management-thermal-updater\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"lldp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"monit\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"netfilter-persistent\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"nv-syncd-shared\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"otel\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"pmon\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"procdockerstatsd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"process-reboot-cause\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"radv\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ras-mc-ctl\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"restapi\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"rsyslog\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"smartmontools\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"snmp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ssh\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"swss\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"syncd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"sysfsutils\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"sysstat\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"teamd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"telemetry\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"}]}"
    >
  >
>

``` 

**Arista device**
**CLI output**
```
admin@str4-7060x6-512-11:~$ show system-health sysready-status
System is not ready - one or more services are not up

Service-Name            Service-Status    App-Ready-Status    Down-Reason
----------------------  ----------------  ------------------  --------------
acms                    OK                OK                  -
audit-rules             OK                OK                  -
auditd                  OK                OK                  -
bgp                     OK                OK                  -
caclmgrd                OK                OK                  -
chrony                  OK                OK                  -
config-chassisdb        OK                OK                  -
config-setup            OK                OK                  -
containerd              OK                OK                  -
core_uploader           OK                OK                  -
cron                    OK                OK                  -
ctrmgrd                 OK                OK                  -
database                OK                OK                  -
determine-reboot-cause  OK                OK                  -
docker                  OK                OK                  -
e2scrub_reap            OK                OK                  -
eventd                  OK                OK                  -
gnmi                    OK                OK                  -
gnoi-shutdown           Down              Down                exec-condition
lldp                    OK                OK                  -
monit                   OK                OK                  -
netfilter-persistent    OK                OK                  -
opennsl-modules         OK                OK                  -
otel                    OK                OK                  -
phy-credo               OK                OK                  -
phy-credo-daemon        OK                OK                  -
pmon                    OK                OK                  -
procdockerstatsd        OK                OK                  -
process-reboot-cause    OK                OK                  -
radv                    OK                OK                  -
ras-mc-ctl              OK                OK                  -
restapi                 OK                OK                  -
rsyslog                 OK                OK                  -
smartmontools           OK                OK                  -
snmp                    OK                OK                  -
ssh                     OK                OK                  -
swss                    OK                OK                  -
syncd                   OK                OK                  -
sysfsutils              OK                OK                  -
sysstat                 OK                OK                  -
teamd                   OK                OK                  -
telemetry               OK                OK                  -
admin@str4-7060x6-512-11:~$
``` 

**gNMIoutput-**

```
root@str4-7060x6-512-11:/# gnmi_get -xpath_target SHOW -xpath system-health/sysready-status -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "system-health"
  >
  elem: <
    name: "sysready-status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777539430101938322
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "system-health"
      >
      elem: <
        name: "sysready-status"
      >
    >
    val: <
      json_ietf_val: "{\"system_status\":\"System is not ready - one or more services are not up\",\"services\":[{\"service_name\":\"acms\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"audit-rules\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"auditd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"bgp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"caclmgrd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"chrony\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"config-chassisdb\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"config-setup\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"containerd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"core_uploader\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"cron\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ctrmgrd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"database\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"determine-reboot-cause\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"docker\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"e2scrub_reap\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"eventd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"gnmi\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"gnoi-shutdown\",\"service_status\":\"Down\",\"app_ready_status\":\"Down\",\"down_reason\":\"exec-condition\"},{\"service_name\":\"lldp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"monit\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"netfilter-persistent\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"opennsl-modules\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"otel\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"phy-credo\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"phy-credo-daemon\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"pmon\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"procdockerstatsd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"process-reboot-cause\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"radv\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ras-mc-ctl\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"restapi\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"rsyslog\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"smartmontools\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"snmp\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"ssh\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"swss\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"syncd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"sysfsutils\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"sysstat\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"teamd\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"},{\"service_name\":\"telemetry\",\"service_status\":\"OK\",\"app_ready_status\":\"OK\",\"down_reason\":\"-\"}]}"
    >
  >
>

``` 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

