### PR TITLE
Onboard show platform syseeprom command

### DIFF
--- a/gnmi_server/platform_cli_test.go
+++ b/gnmi_server/platform_cli_test.go
@@ -6,6 +6,7 @@ package gnmi
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	sccommon "github.com/sonic-net/sonic-gnmi/show_client/common"
+	"github.com/sonic-net/sonic-gnmi/show_client/helpers"
 )
 
 func TestGetShowPlatformSummary(t *testing.T) {
@@ -503,6 +505,168 @@ func TestGetShowPlatformCurrent(t *testing.T) {
 			if tt.testInit != nil {
 				tt.testInit()
 			}
+
+			s := createServer(t, ServerPort)
+			go runServer(t, s)
+			defer s.ForceStop()
+
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+			conn, err := grpc.Dial(TargetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+			}
+			defer conn.Close()
+
+			gClient := pb.NewGNMIClient(conn)
+			ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, tt.pathTarget, tt.textPbPath, tt.wantRetCode, tt.wantRespVal, tt.valTest)
+		})
+	}
+}
+
+func TestGetShowPlatformSyseeprom(t *testing.T) {
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func() *gomonkey.Patches
+	}{
+		{
+			desc:       "query SHOW platform syseeprom - full EEPROM data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "syseeprom" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: func() []byte {
+				expected := helpers.SysEepromInfo{
+					TlvInfoHeader: helpers.SysEepromHeader{
+						IdString:    "TlvInfo",
+						Version:     "1",
+						TotalLength: "169",
+					},
+					TlvList: []helpers.SysEepromTlv{
+						{Name: "Product Name", Code: "0x21", Length: "12", Value: "DCS-7060CX-32"},
+						{Name: "Part Number", Code: "0x22", Length: "14", Value: "FP-T3048-C32-R"},
+						{Name: "Serial Number", Code: "0x23", Length: "11", Value: "JPE20381234"},
+						{Name: "Base MAC Address", Code: "0x24", Length: "6", Value: "00:1C:73:01:23:45"},
+						{Name: "Manufacture Date", Code: "0x25", Length: "19", Value: "01/01/2024 00:00:00"},
+						{Name: "Device Version", Code: "0x26", Length: "1", Value: "2"},
+						{Name: "Label Revision", Code: "0x27", Length: "3", Value: "R01"},
+						{Name: "Platform Name", Code: "0x28", Length: "30", Value: "x86_64-mlnx_msn3700-r0"},
+						{Name: "ONIE Version", Code: "0x29", Length: "12", Value: "2024.02.01.0"},
+						{Name: "MAC Addresses", Code: "0x2A", Length: "2", Value: "256"},
+						{Name: "Manufacturer", Code: "0x2B", Length: "8", Value: "Mellanox"},
+						{Name: "Vendor Extension", Code: "0xFD", Length: "36", Value: "0x00 0x00 0x81 0x19 0x02 0x40 0x44 0x65"},
+						{Name: "Vendor Extension", Code: "0xFD", Length: "36", Value: "0x00 0x00 0x81 0x19 0x02 0x40 0x44 0x66"},
+						{Name: "CRC-32", Code: "0xFE", Length: "4", Value: "0xABCDEF01"},
+					},
+					ChecksumValid: true,
+				}
+				jsonData, _ := json.Marshal(expected)
+				return jsonData
+			}(),
+			valTest: true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				AddDataSet(t, StateDbNum, "../testdata/SYSEEPROM.txt")
+				return gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {
+					return "x86_64-mlnx_msn3700-r0"
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform syseeprom - not initialized",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "syseeprom" >
+			`,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				AddDataSet(t, StateDbNum, "../testdata/SYSEEPROM_NOT_INITIALIZED.txt")
+				return gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {
+					return "x86_64-mlnx_msn3700-r0"
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform syseeprom - no data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "syseeprom" >
+			`,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				return gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {
+					return "x86_64-mlnx_msn3700-r0"
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform syseeprom - KVM platform not supported",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "syseeprom" >
+			`,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				return gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {
+					return "x86_64-kvm_x86_64-r0"
+				})
+			},
+		},
+		{
+			desc:       "query SHOW platform syseeprom - Arista platform uses nsenter fallback",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "platform" >
+				elem: <name: "syseeprom" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte("SKU: DCS-7060X6-64PE-B\nSerialNumber: HBG251204WB\nMAC: d8:06:f3:5a:a9:b1\nHwRev: 11.00"),
+			valTest:     true,
+			testInit: func() *gomonkey.Patches {
+				ResetDataSetsAndMappings(t)
+				patches := gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {
+					return "x86_64-arista_7050-r0"
+				})
+				eepromText := "SKU: DCS-7060X6-64PE-B\nSerialNumber: HBG251204WB\nMAC: d8:06:f3:5a:a9:b1\nHwRev: 11.00"
+				patches.ApplyFunc(sccommon.GetDataFromHostCommand, func(command string) (string, error) {
+					return eepromText, nil
+				})
+				return patches
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var patches *gomonkey.Patches
+			if tt.testInit != nil {
+				patches = tt.testInit()
+			}
+			defer func() {
+				if patches != nil {
+					patches.Reset()
+				}
+			}()
 
 			s := createServer(t, ServerPort)
 			go runServer(t, s)

--- a/gnmi_server/platform_cli_test.go
+++ b/gnmi_server/platform_cli_test.go
@@ -640,8 +640,12 @@ func TestGetShowPlatformSyseeprom(t *testing.T) {
 				elem: <name: "syseeprom" >
 			`,
 			wantRetCode: codes.OK,
-			wantRespVal: []byte("SKU: DCS-7060X6-64PE-B\nSerialNumber: HBG251204WB\nMAC: d8:06:f3:5a:a9:b1\nHwRev: 11.00"),
-			valTest:     true,
+			wantRespVal: func() []byte {
+				result := map[string]string{"eeprom_raw": "SKU: DCS-7060X6-64PE-B\nSerialNumber: HBG251204WB\nMAC: d8:06:f3:5a:a9:b1\nHwRev: 11.00"}
+				jsonData, _ := json.Marshal(result)
+				return jsonData
+			}(),
+			valTest: true,
 			testInit: func() *gomonkey.Patches {
 				ResetDataSetsAndMappings(t)
 				patches := gomonkey.ApplyFunc(sccommon.GetPlatform, func() string {

--- a/show_client/common/platform_apis.go
+++ b/show_client/common/platform_apis.go
@@ -1,0 +1,16 @@
+package common
+
+// SysEepromPyScript is the Python script that invokes the sonic_platform API
+// to retrieve system EEPROM info.
+var SysEepromPyScript = `
+import sys
+try:
+    import sonic_platform
+    eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
+except Exception:
+    eeprom = None
+if not eeprom:
+    sys.exit(1)
+sys_eeprom_data = eeprom.read_eeprom()
+eeprom.decode_eeprom(sys_eeprom_data)
+`

--- a/show_client/helpers/platform_syseeprom_helper.go
+++ b/show_client/helpers/platform_syseeprom_helper.go
@@ -110,7 +110,9 @@ func ReadEepromViaPlatformApi() ([]byte, error) {
 		return nil, fmt.Errorf("empty response from platform EEPROM API")
 	}
 
-	return []byte(output), nil
+	// Wrap raw text in JSON since gNMI response uses JsonIetfVal
+	result := map[string]string{"eeprom_raw": output}
+	return json.Marshal(result)
 }
 
 // ReadEepromFromDb reads EEPROM data cached in STATE_DB by syseepromd.

--- a/show_client/helpers/platform_syseeprom_helper.go
+++ b/show_client/helpers/platform_syseeprom_helper.go
@@ -1,0 +1,214 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/sonic-net/sonic-gnmi/show_client/common"
+)
+
+// --- EEPROM / syseeprom ---
+
+const (
+	eepromInfoTable = "EEPROM_INFO"
+
+	// Special EEPROM_INFO keys (not TLV codes)
+	eepromStateKey     = "State"
+	eepromTlvHeaderKey = "TlvHeader"
+	eepromChecksumKey  = "Checksum"
+)
+
+// Default TLV type codes (matching Python TlvInfoDecoder).
+const (
+	TlvCodeProductName   = 0x21
+	TlvCodePartNumber    = 0x22
+	TlvCodeSerialNumber  = 0x23
+	TlvCodeMacBase       = 0x24
+	TlvCodeManufDate     = 0x25
+	TlvCodeDeviceVersion = 0x26
+	TlvCodeLabelRevision = 0x27
+	TlvCodePlatformName  = 0x28
+	TlvCodeOnieVersion   = 0x29
+	TlvCodeMacSize       = 0x2A
+	TlvCodeManufName     = 0x2B
+	TlvCodeManufCountry  = 0x2C
+	TlvCodeVendorName    = 0x2D
+	TlvCodeDiagVersion   = 0x2E
+	TlvCodeServiceTag    = 0x2F
+	TlvCodeVendorExt     = 0xFD
+	TlvCodeCrc32         = 0xFE
+)
+
+// eepromTlvCodes lists TLV codes in display order.
+// Built in init() to mirror Python: range(PRODUCT_NAME, SERVICE_TAG+1) + VENDOR_EXT + CRC_32.
+var eepromTlvCodes []int
+
+func init() {
+	for code := TlvCodeProductName; code <= TlvCodeServiceTag; code++ {
+		eepromTlvCodes = append(eepromTlvCodes, code)
+	}
+	eepromTlvCodes = append(eepromTlvCodes, TlvCodeVendorExt)
+	eepromTlvCodes = append(eepromTlvCodes, TlvCodeCrc32)
+}
+
+// SysEepromInfo is the top-level JSON response for "show platform syseeprom".
+type SysEepromInfo struct {
+	TlvInfoHeader SysEepromHeader `json:"tlv_info_header"`
+	TlvList       []SysEepromTlv  `json:"tlv_list"`
+	ChecksumValid bool            `json:"checksum_valid"`
+}
+
+// SysEepromHeader holds the TlvInfo header fields.
+type SysEepromHeader struct {
+	IdString    string `json:"id_string"`
+	Version     string `json:"version"`
+	TotalLength string `json:"total_length"`
+}
+
+// SysEepromTlv represents one TLV entry in the EEPROM.
+type SysEepromTlv struct {
+	Name   string `json:"tlv_name"`
+	Code   string `json:"code"`
+	Length string `json:"length"`
+	Value  string `json:"value"`
+}
+
+// PlatformsWithoutEepromDb lists platforms that do not support EEPROM DB
+// (must fall back to platform API via nsenter).
+var PlatformsWithoutEepromDb = []string{`(?i).*arista.*`, `(?i).*kvm.*`}
+
+// PlatformsWithoutEeprom lists platforms that do not support EEPROM at all.
+var PlatformsWithoutEeprom = []string{`(?i).*kvm.*`}
+
+// MatchesPlatformPattern checks if platform matches any of the given regex patterns.
+func MatchesPlatformPattern(platform string, patterns []string) bool {
+	for _, p := range patterns {
+		if matched, _ := regexp.MatchString(p, platform); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadEepromViaPlatformApi reads EEPROM data by invoking the sonic_platform
+// Python API on the host via nsenter (for platforms without EEPROM DB support).
+// Returns the raw text output from decode_eeprom() — format varies by vendor.
+func ReadEepromViaPlatformApi() ([]byte, error) {
+	escaped := strings.ReplaceAll(common.SysEepromPyScript, "'", `'\''`)
+	pyCmd := fmt.Sprintf("python3 -c '%s'", escaped)
+	output, err := common.GetDataFromHostCommand(pyCmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read EEPROM via platform API: %w", err)
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, fmt.Errorf("empty response from platform EEPROM API")
+	}
+
+	return []byte(output), nil
+}
+
+// ReadEepromFromDb reads EEPROM data cached in STATE_DB by syseepromd.
+func ReadEepromFromDb() ([]byte, error) {
+	// Bulk-read all EEPROM_INFO entries from STATE_DB
+	queries := [][]string{
+		{common.StateDb, eepromInfoTable},
+	}
+	allData, err := common.GetMapFromQueries(queries)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query EEPROM_INFO from STATE_DB: %w", err)
+	}
+
+	// Check initialization state
+	stateData, ok := allData[eepromStateKey].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("EEPROM data not available - syseepromd may not have initialized yet")
+	}
+	initialized := common.GetValueOrDefault(stateData, "Initialized", "")
+	if initialized != "1" {
+		return nil, fmt.Errorf("EEPROM data not initialized (Initialized=%q) - syseepromd may still be starting", initialized)
+	}
+
+	// Parse TlvHeader
+	header := SysEepromHeader{
+		IdString:    "N/A",
+		Version:     "N/A",
+		TotalLength: "N/A",
+	}
+	if headerData, ok := allData[eepromTlvHeaderKey].(map[string]interface{}); ok {
+		header.IdString = common.GetValueOrDefault(headerData, "Id String", "N/A")
+		header.Version = common.GetValueOrDefault(headerData, "Version", "N/A")
+		header.TotalLength = common.GetValueOrDefault(headerData, "Total Length", "N/A")
+	}
+
+	// Parse TLV entries in defined order
+	tlvList := make([]SysEepromTlv, 0)
+	for _, code := range eepromTlvCodes {
+		codeStr := fmt.Sprintf("0x%02X", code)
+		tlvData, ok := allData[strings.ToLower(codeStr)].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if code == TlvCodeVendorExt {
+			// Vendor Extension: multiple sub-entries
+			tlvList = append(tlvList, parseVendorExtensions(codeStr, tlvData)...)
+		} else {
+			tlv := SysEepromTlv{
+				Code:   codeStr,
+				Name:   common.GetValueOrDefault(tlvData, "Name", "N/A"),
+				Length: common.GetValueOrDefault(tlvData, "Len", "N/A"),
+				Value:  common.GetValueOrDefault(tlvData, "Value", "N/A"),
+			}
+			tlvList = append(tlvList, tlv)
+		}
+	}
+
+	// Parse checksum validity
+	checksumValid := false
+	if checksumData, ok := allData[eepromChecksumKey].(map[string]interface{}); ok {
+		validStr := common.GetValueOrDefault(checksumData, "Valid", "0")
+		checksumValid = (validStr == "1")
+	}
+
+	result := SysEepromInfo{
+		TlvInfoHeader: header,
+		TlvList:       tlvList,
+		ChecksumValid: checksumValid,
+	}
+	return json.Marshal(result)
+}
+
+// parseVendorExtensions expands the vendor extension TLV (0xFD) which can contain
+// multiple sub-entries indexed by Name_0, Len_0, Value_0, Name_1, etc.
+func parseVendorExtensions(codeStr string, data map[string]interface{}) []SysEepromTlv {
+	numStr := common.GetValueOrDefault(data, "Num_vendor_ext", "0")
+	numVendorExt, err := strconv.Atoi(numStr)
+	if err != nil || numVendorExt <= 0 {
+		log.V(2).Infof("parseVendorExtensions: no vendor extensions (Num_vendor_ext=%q)", numStr)
+		return nil
+	}
+
+	tlvs := make([]SysEepromTlv, 0, numVendorExt)
+	for i := 0; i < numVendorExt; i++ {
+		name := common.GetValueOrDefault(data, fmt.Sprintf("Name_%d", i), "")
+		length := common.GetValueOrDefault(data, fmt.Sprintf("Len_%d", i), "")
+		value := common.GetValueOrDefault(data, fmt.Sprintf("Value_%d", i), "")
+		if name == "" && length == "" && value == "" {
+			log.V(2).Infof("parseVendorExtensions: skipping empty entry at index %d", i)
+			continue
+		}
+		tlvs = append(tlvs, SysEepromTlv{
+			Code:   codeStr,
+			Name:   name,
+			Length: length,
+			Value:  value,
+		})
+	}
+	return tlvs
+}

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -395,7 +395,6 @@ func getPlatformCurrent(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 }
 
 // getPlatformSyseeprom implements "show platform syseeprom".
-// Replicates the Python decode-syseeprom logic:
 //  1. Get platform name
 //  2. If platform matches kvm → return "does not support EEPROM"
 //  3. If platform matches arista or kvm → no DB support, use platform API via nsenter

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -393,3 +393,28 @@ func getPlatformCurrent(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error)
 		}
 	})
 }
+
+// getPlatformSyseeprom implements "show platform syseeprom".
+// Replicates the Python decode-syseeprom logic:
+//  1. Get platform name
+//  2. If platform matches kvm → return "does not support EEPROM"
+//  3. If platform matches arista or kvm → no DB support, use platform API via nsenter
+//  4. Otherwise → read from STATE_DB (EEPROM_INFO cached by syseepromd)
+func getPlatformSyseeprom(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {
+	platform := common.GetPlatform()
+	log.V(2).Infof("getPlatformSyseeprom: detected platform=%q", platform)
+
+	// Platforms that do not support EEPROM at all
+	if helpers.MatchesPlatformPattern(platform, helpers.PlatformsWithoutEeprom) {
+		return nil, fmt.Errorf("platform %s does not support EEPROM", platform)
+	}
+
+	// Platforms without EEPROM DB support — fall back to platform API via nsenter
+	if helpers.MatchesPlatformPattern(platform, helpers.PlatformsWithoutEepromDb) {
+		log.V(2).Infof("getPlatformSyseeprom: platform %q does not support EEPROM DB, using platform API", platform)
+		return helpers.ReadEepromViaPlatformApi()
+	}
+
+	// Default path: read from STATE_DB (equivalent to decode-syseeprom -d)
+	return helpers.ReadEepromFromDb()
+}

--- a/show_client/platform_cli.go
+++ b/show_client/platform_cli.go
@@ -433,6 +433,7 @@ func getPlatformSyseeprom(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, erro
 
 	// Default path: read from STATE_DB (equivalent to decode-syseeprom -d)
 	return helpers.ReadEepromFromDb()
+}
 
 // getPlatformSsdhealth implements the "show platform ssdhealth" command.
 func getPlatformSsdhealth(args sdc.CmdArgs, options sdc.OptionMap) ([]byte, error) {

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1131,4 +1131,14 @@ func init() {
 		0,
 		nil,
 	)
+
+	// SHOW/platform/syseeprom
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "platform", "syseeprom"},
+		getPlatformSyseeprom,
+		"SHOW/platform/syseeprom: Show system EEPROM information",
+		0,
+		0,
+		nil,
+	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -1174,7 +1174,7 @@ func init() {
 		nil,
 	)
 
-  // SHOW/platform/syseeprom
+	// SHOW/platform/syseeprom
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "platform", "syseeprom"},
 		getPlatformSyseeprom,

--- a/testdata/SYSEEPROM.txt
+++ b/testdata/SYSEEPROM.txt
@@ -1,0 +1,82 @@
+{
+    "EEPROM_INFO|State": {
+        "Initialized": "1"
+    },
+    "EEPROM_INFO|TlvHeader": {
+        "Id String": "TlvInfo",
+        "Version": "1",
+        "Total Length": "169"
+    },
+    "EEPROM_INFO|0x21": {
+        "Name": "Product Name",
+        "Len": "12",
+        "Value": "DCS-7060CX-32"
+    },
+    "EEPROM_INFO|0x22": {
+        "Name": "Part Number",
+        "Len": "14",
+        "Value": "FP-T3048-C32-R"
+    },
+    "EEPROM_INFO|0x23": {
+        "Name": "Serial Number",
+        "Len": "11",
+        "Value": "JPE20381234"
+    },
+    "EEPROM_INFO|0x24": {
+        "Name": "Base MAC Address",
+        "Len": "6",
+        "Value": "00:1C:73:01:23:45"
+    },
+    "EEPROM_INFO|0x25": {
+        "Name": "Manufacture Date",
+        "Len": "19",
+        "Value": "01/01/2024 00:00:00"
+    },
+    "EEPROM_INFO|0x26": {
+        "Name": "Device Version",
+        "Len": "1",
+        "Value": "2"
+    },
+    "EEPROM_INFO|0x27": {
+        "Name": "Label Revision",
+        "Len": "3",
+        "Value": "R01"
+    },
+    "EEPROM_INFO|0x28": {
+        "Name": "Platform Name",
+        "Len": "30",
+        "Value": "x86_64-mlnx_msn3700-r0"
+    },
+    "EEPROM_INFO|0x29": {
+        "Name": "ONIE Version",
+        "Len": "12",
+        "Value": "2024.02.01.0"
+    },
+    "EEPROM_INFO|0x2a": {
+        "Name": "MAC Addresses",
+        "Len": "2",
+        "Value": "256"
+    },
+    "EEPROM_INFO|0x2b": {
+        "Name": "Manufacturer",
+        "Len": "8",
+        "Value": "Mellanox"
+    },
+    "EEPROM_INFO|0xfd": {
+        "Num_vendor_ext": "2",
+        "Name_0": "Vendor Extension",
+        "Len_0": "36",
+        "Value_0": "0x00 0x00 0x81 0x19 0x02 0x40 0x44 0x65",
+        "Name_1": "Vendor Extension",
+        "Len_1": "36",
+        "Value_1": "0x00 0x00 0x81 0x19 0x02 0x40 0x44 0x66"
+    },
+    "EEPROM_INFO|0xfe": {
+        "Name": "CRC-32",
+        "Len": "4",
+        "Value": "0xABCDEF01"
+    },
+    "EEPROM_INFO|Checksum": {
+        "Valid": "1"
+    }
+}

--- a/testdata/SYSEEPROM_NOT_INITIALIZED.txt
+++ b/testdata/SYSEEPROM_NOT_INITIALIZED.txt
@@ -1,0 +1,5 @@
+{
+    "EEPROM_INFO|State": {
+        "Initialized": "0"
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
MSFT ADO-37750120
#### Why I did it
Onboarded show platform syseeprom command to gNMI server system eeprom data can be queried programmatically via gNMI Get RPCs.
#### How I did it

The show platform syseeprom command reads EEPROM data from two paths: for most platforms, it queries EEPROM_INFO from STATE_DB (populated by syseepromd) and assembles a structured JSON with TLV header, entries, and checksum; for platforms without DB support (Arista), it runs decode_eeprom() via nsenter and wraps the raw vendor-specific text in {"eeprom_raw": "..."}. Platform detection uses regex patterns against the platform name to route between the DB path, the nsenter fallback, or an error for unsupported platforms like KVM.

#### How to verify it
**Mellanox device**
**CLI output-**
```
show platform syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 607
TLV Name          Code      Len  Value
----------------  ------  -----  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Product Name      0x21       64  MSN4600C
Part Number       0x22       20  MSN4600-CS2ROS
Serial Number     0x23       24  MT2349J00XZC
Base MAC Address  0x24        6  9C:05:91:CF:DC:00
Manufacture Date  0x25       19  12/13/2023 22:41:04
Device Version    0x26        1  19
Platform Name     0x28       64  x86_64-mlnx_msn4600C-r0
ONIE Version      0x29       21  2021.05-5.3.0008-9600
MAC Addresses     0x2A        2  254
Manufacturer      0x2B        8  Mellanox
Vendor Name       0x2D       10
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD      164  0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0x1F 0x00 0x00 0x4D 0x54 0x32 0x33 0x34 0x39 0x4A 0x30 0x30 0x58 0x5A 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x2D 0x43 0x53 0x32 0x52 0x4F 0x53 0x00 0x00 0x00 0x00 0x00 0x00 0x42 0x32 0x00 0x00 0x00 0x7F 0x50 0xE0 0x54 0x69 0x67 0x6F 0x6E 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x7C 0x13 0x00 0x07 0x04 0xED 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0x07 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x9C 0x05 0x91 0xCF 0xDC 0x00 0x00 0xFE 0x9C 0x05 0x91 0x03 0x00 0xCF 0xDC 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       20  0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x79 0x00 0x00 0x30 0x00 0x40 0x00 0x00 0x00 0x00 0x00
CRC-32            0xFE        4  0x0AD290EB

(checksum valid)
``` 
**gNMI output**
```
docker exec -it telemetry bash
root@bjw2-can-4600c-5:/# gnmi_get -xpath_target SHOW -xpath platform/syseeprom -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "syseeprom"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777542592436191007
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "syseeprom"
      >
    >
    val: <
      json_ietf_val: "{\"tlv_info_header\":{\"id_string\":\"TlvInfo\",\"version\":\"1\",\"total_length\":\"607\"},\"tlv_list\":[{\"tlv_name\":\"Product Name\",\"code\":\"0x21\",\"length\":\"64\",\"value\":\"MSN4600C\"},{\"tlv_name\":\"Part Number\",\"code\":\"0x22\",\"length\":\"20\",\"value\":\"MSN4600-CS2ROS\"},{\"tlv_name\":\"Serial Number\",\"code\":\"0x23\",\"length\":\"24\",\"value\":\"MT2349J00XZC\"},{\"tlv_name\":\"Base MAC Address\",\"code\":\"0x24\",\"length\":\"6\",\"value\":\"9C:05:91:CF:DC:00\"},{\"tlv_name\":\"Manufacture Date\",\"code\":\"0x25\",\"length\":\"19\",\"value\":\"12/13/2023 22:41:04\"},{\"tlv_name\":\"Device Version\",\"code\":\"0x26\",\"length\":\"1\",\"value\":\"19\"},{\"tlv_name\":\"Platform Name\",\"code\":\"0x28\",\"length\":\"64\",\"value\":\"x86_64-mlnx_msn4600C-r0\"},{\"tlv_name\":\"ONIE Version\",\"code\":\"0x29\",\"length\":\"21\",\"value\":\"2021.05-5.3.0008-9600\"},{\"tlv_name\":\"MAC Addresses\",\"code\":\"0x2A\",\"length\":\"2\",\"value\":\"254\"},{\"tlv_name\":\"Manufacturer\",\"code\":\"0x2B\",\"length\":\"8\",\"value\":\"Mellanox\"},{\"tlv_name\":\"Vendor Name\",\"code\":\"0x2D\",\"length\":\"10\",\"value\":\"\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"36\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"164\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0x1F 0x00 0x00 0x4D 0x54 0x32 0x33 0x34 0x39 0x4A 0x30 0x30 0x58 0x5A 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x2D 0x43 0x53 0x32 0x52 0x4F 0x53 0x00 0x00 0x00 0x00 0x00 0x00 0x42 0x32 0x00 0x00 0x00 0x7F 0x50 0xE0 0x54 0x69 0x67 0x6F 0x6E 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x7C 0x13 0x00 0x07 0x04 0xED 0x4D 0x53 0x4E 0x34 0x36 0x30 0x30 0x43 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"36\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"36\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0x07 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x9C 0x05 0x91 0xCF 0xDC 0x00 0x00 0xFE 0x9C 0x05 0x91 0x03 0x00 0xCF 0xDC 0x00\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"36\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00\"},{\"tlv_name\":\"Vendor Extension\",\"code\":\"0xFD\",\"length\":\"20\",\"value\":\"0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x79 0x00 0x00 0x30 0x00 0x40 0x00 0x00 0x00 0x00 0x00\"},{\"tlv_name\":\"CRC-32\",\"code\":\"0xFE\",\"length\":\"4\",\"value\":\"0x0AD290EB\"}],\"checksum_valid\":true}"
    >
  >
>

root@bjw2-can-4600c-5:/# exit
``` 


**Arista device-**
**CLI output**
```
admin@str4-7060x6-512-11:~$ show platform syseeprom
ASY: ASY0899401A0
HwApi: 02.00
HwRev: 11.00
MAC: d8:06:f3:5a:a9:b1
MfgTime: 20200101000000
MfgTime2: 20250323092804
SID: QuicksilverP512
SKU: DCS-7060X6-64PE-B
SerialNumber: HBG251204WB
``` 

**gNMI output** - returning raw string here for below reasons-
-> The output here is fetched from platform apis(not db) which can be any format, so merely parsing it based on newline characters/colons may break.
-> The raw string can be returned as-is, since the client already incorporates an extra level of parsing logic to handle it appropriately.
```
root@str4-7060x6-512-11:/# gnmi_get -xpath_target SHOW -xpath platform/syseeprom -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "platform"
  >
  elem: <
    name: "syseeprom"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1777542151584832178
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "platform"
      >
      elem: <
        name: "syseeprom"
      >
    >
    val: <
      json_ietf_val: "{\"eeprom_raw\":\"ASY: ASY0899401A0\\nHwApi: 02.00\\nHwRev: 11.00\\nMAC: d8:06:f3:5a:a9:b1\\nMfgTime: 20200101000000\\nMfgTime2: 20250323092804\\nSID: QuicksilverP512\\nSKU: DCS-7060X6-64PE-B\\nSerialNumber: HBG251204WB\"}"
    >
  >
>
``` 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

