### PR TITLE
Update json tags and argument count for management interface address and arp cmds

### DIFF
--- a/gnmi_server/management_interface_address_cli_test.go
+++ b/gnmi_server/management_interface_address_cli_test.go
@@ -34,7 +34,7 @@ func TestGetManagementInterfaceAddress(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
 	defer cancel()
 
-	expectedManagementInterface := `[{"Management IP address":"10.0.0.5/8","Management Network Default Gateway":"10.0.0.1"},{"Management IP address":"192.168.1.100/24","Management Network Default Gateway":"192.168.1.1"}]`
+	expectedManagementInterface := `[{"":"10.0.0.5/8","management_network_default_gateway":"10.0.0.1"},{"":"192.168.1.100/24","management_network_default_gateway":"192.168.1.1"}]`
 
 	tests := []struct {
 		desc        string
@@ -96,7 +96,7 @@ func TestGetManagementInterfaceAddress(t *testing.T) {
 				elem: <name: "address" >
 			`,
 			wantRetCode: codes.OK,
-			wantRespVal: []byte(`[{"Management IP address":"192.168.1.100/24","Management Network Default Gateway":""}]`),
+			wantRespVal: []byte(`[{"":"192.168.1.100/24","management_network_default_gateway":""}]`),
 			valTest:     true,
 			testInit: func() *gomonkey.Patches {
 				patches := gomonkey.NewPatches()

--- a/gnmi_server/management_interface_address_cli_test.go
+++ b/gnmi_server/management_interface_address_cli_test.go
@@ -34,7 +34,7 @@ func TestGetManagementInterfaceAddress(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
 	defer cancel()
 
-	expectedManagementInterface := `[{"":"10.0.0.5/8","management_network_default_gateway":"10.0.0.1"},{"":"192.168.1.100/24","management_network_default_gateway":"192.168.1.1"}]`
+	expectedManagementInterface := `[{"management_ip_address":"10.0.0.5/8","management_network_default_gateway":"10.0.0.1"},{"management_ip_address":"192.168.1.100/24","management_network_default_gateway":"192.168.1.1"}]`
 
 	tests := []struct {
 		desc        string
@@ -96,7 +96,7 @@ func TestGetManagementInterfaceAddress(t *testing.T) {
 				elem: <name: "address" >
 			`,
 			wantRetCode: codes.OK,
-			wantRespVal: []byte(`[{"":"192.168.1.100/24","management_network_default_gateway":""}]`),
+			wantRespVal: []byte(`[{"management_ip_address":"192.168.1.100/24","management_network_default_gateway":""}]`),
 			valTest:     true,
 			testInit: func() *gomonkey.Patches {
 				patches := gomonkey.NewPatches()

--- a/show_client/management_interface_address_cli.go
+++ b/show_client/management_interface_address_cli.go
@@ -12,8 +12,8 @@ import (
 
 // ManagementInterfaceAddress represents a single management interface address entry
 type ManagementInterfaceAddress struct {
-	ManagementIPAddress             string `json:"Management IP address"`
-	ManagementNetworkDefaultGateway string `json:"Management Network Default Gateway"`
+	ManagementIPAddress             string `json:"management_ip_address"`
+	ManagementNetworkDefaultGateway string `json:"management_network_default_gateway"`
 }
 
 const (

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -861,7 +861,7 @@ func init() {
 		getARP,
 		"SHOW/arp/{ipaddress}[OPTIONS]: Show IP ARP table",
 		0,
-		2,
+		1,
 		nil,
 		showCmdOptionSonicCliIfaceMode,
 		showCmdOptionIface,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The show arp command accepts at most 1 argument (an IP address), but the max argument is declared as 2 in show paths.go.

#### How I did it
Fixed the max argument count from 2 to 1 in show_paths.go. Additionally, normalized the management interface JSON keys from title-case ("Management IP address") to snake_case("management_ip_address") for consistency with the API contract, and updated the corresponding tests.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

